### PR TITLE
feat: Support ConfigMap templates

### DIFF
--- a/fixtures/output/small-configmap.yaml
+++ b/fixtures/output/small-configmap.yaml
@@ -1,0 +1,7 @@
+data:
+  MY_NONSECRET_NUM: "5"
+  MY_NONSECRET_STRING: foo
+metadata:
+  creationTimestamp: null
+  name: my-app
+  namespace: default

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -1,0 +1,82 @@
+package kube
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/IBM/argocd-vault-plugin/pkg/vault"
+	corev1 "k8s.io/api/core/v1"
+	k8yaml "sigs.k8s.io/yaml"
+)
+
+// ConfigMapTemplate is the template for Kubernetes ConfigMaps
+type ConfigMapTemplate struct {
+	Resource
+}
+
+// NewConfigMapTemplate returns a *ConfigMapTemplate given the template's data, and a VaultType
+func NewConfigMapTemplate(template map[string]interface{}, vault vault.VaultType) (*ConfigMapTemplate, error) {
+	path := os.Getenv("VAULT_PATH_PREFIX")
+	data, err := vault.GetSecrets(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConfigMapTemplate{
+		Resource{
+			templateData: template,
+			vaultData:    data,
+		},
+	}, nil
+}
+
+// Replace will replace the <placeholders> in the template's data with values from Vault.
+// It will return an aggregrate of any errors encountered during the replacements
+func (d *ConfigMapTemplate) Replace() error {
+
+	// Assuming all other fields of a configMap (besides `data`) will have string values
+	replaceInner(&d.Resource, &d.templateData, configMapReplacement)
+	if len(d.replacementErrors) != 0 {
+
+		// TODO format multiple errors nicely
+		return fmt.Errorf("Replace: could not replace all placeholders in ConfigMapTemplate: %s", d.replacementErrors)
+	}
+	return nil
+}
+
+func configMapReplacement(key, value string, vaultData map[string]interface{}) (interface{}, []error) {
+	res, err := genericReplacement(key, value, vaultData)
+	if err != nil {
+		return nil, err
+	}
+	// configMap data values must be strings
+	switch res.(type) {
+	case int:
+		{
+			return strconv.Itoa(res.(int)), err
+		}
+	case bool:
+		{
+			return strconv.FormatBool(res.(bool)), err
+		}
+	default:
+		{
+			return res.(string), err
+		}
+	}
+}
+
+// ToYAML seralizes the completed template into YAML to be consumed by Kubernetes
+func (d *ConfigMapTemplate) ToYAML() (string, error) {
+	kubeResource := corev1.ConfigMap{}
+	err := kubeResourceDecoder(&d.templateData).Decode(&kubeResource)
+	if err != nil {
+		return "", fmt.Errorf("ToYAML: could not convert replaced template into ConfigMap: %s", err)
+	}
+	res, err := k8yaml.Marshal(&kubeResource)
+	if err != nil {
+		return "", fmt.Errorf("ToYAML: could not export ConfigMap into YAML: %s", err)
+	}
+	return string(res), nil
+}

--- a/pkg/kube/configmap.go
+++ b/pkg/kube/configmap.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/vault"
 	corev1 "k8s.io/api/core/v1"
@@ -51,20 +50,7 @@ func configMapReplacement(key, value string, vaultData map[string]interface{}) (
 		return nil, err
 	}
 	// configMap data values must be strings
-	switch res.(type) {
-	case int:
-		{
-			return strconv.Itoa(res.(int)), err
-		}
-	case bool:
-		{
-			return strconv.FormatBool(res.(bool)), err
-		}
-	default:
-		{
-			return res.(string), err
-		}
-	}
+	return stringify(res), err
 }
 
 // ToYAML seralizes the completed template into YAML to be consumed by Kubernetes

--- a/pkg/kube/configmap_test.go
+++ b/pkg/kube/configmap_test.go
@@ -1,0 +1,131 @@
+package kube
+
+import (
+	"testing"
+)
+
+func TestConfigMapReplacement_string(t *testing.T) {
+	configmap := ConfigMapTemplate{
+		Resource{
+			templateData: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "<namespace>",
+				},
+				"data": map[string]interface{}{
+					"SOME_ENV_VAR": "<env-var>",
+				},
+			},
+			vaultData: map[string]interface{}{
+				"namespace": "default",
+				"env-var":   "foo",
+			},
+		},
+	}
+
+	err := configmap.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := Resource{
+		templateData: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"SOME_ENV_VAR": "foo",
+			},
+		},
+		vaultData: map[string]interface{}{
+			"namespace": "default",
+			"env-var":   "foo",
+		},
+		replacementErrors: []error{},
+	}
+
+	assertSuccessfulReplacement(&configmap.Resource, &expected, t)
+}
+
+func TestConfigMapReplacement_int(t *testing.T) {
+	configmap := ConfigMapTemplate{
+		Resource{
+			templateData: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "<namespace>",
+				},
+				"data": map[string]interface{}{
+					"PORT": "<port>",
+				},
+			},
+			vaultData: map[string]interface{}{
+				"namespace": "default",
+				"port":      5,
+			},
+		},
+	}
+
+	err := configmap.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := Resource{
+		templateData: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"PORT": "5",
+			},
+		},
+		vaultData: map[string]interface{}{
+			"namespace": "default",
+			"port":      5,
+		},
+		replacementErrors: []error{},
+	}
+
+	assertSuccessfulReplacement(&configmap.Resource, &expected, t)
+}
+
+func TestConfigMapReplacement_bool(t *testing.T) {
+	configmap := ConfigMapTemplate{
+		Resource{
+			templateData: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "<namespace>",
+				},
+				"data": map[string]interface{}{
+					"SECRET_FLAG": "<flag>",
+				},
+			},
+			vaultData: map[string]interface{}{
+				"namespace": "default",
+				"flag":      true,
+			},
+		},
+	}
+
+	err := configmap.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := Resource{
+		templateData: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"SECRET_FLAG": "true",
+			},
+		},
+		vaultData: map[string]interface{}{
+			"namespace": "default",
+			"flag":      true,
+		},
+		replacementErrors: []error{},
+	}
+
+	assertSuccessfulReplacement(&configmap.Resource, &expected, t)
+}

--- a/pkg/kube/deployment.go
+++ b/pkg/kube/deployment.go
@@ -1,14 +1,11 @@
 package kube
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/vault"
 	appsv1 "k8s.io/api/apps/v1"
-	k8yamldecoder "k8s.io/apimachinery/pkg/util/yaml"
 	k8yaml "sigs.k8s.io/yaml"
 )
 
@@ -47,10 +44,8 @@ func (d *DeploymentTemplate) Replace() error {
 
 // ToYAML seralizes the completed template into YAML to be consumed by Kubernetes
 func (d *DeploymentTemplate) ToYAML() (string, error) {
-	jsondata, _ := json.Marshal(d.templateData)
-	decoder := k8yamldecoder.NewYAMLOrJSONDecoder(bytes.NewReader(jsondata), 1000)
 	kubeResource := appsv1.Deployment{}
-	err := decoder.Decode(&kubeResource)
+	err := kubeResourceDecoder(&d.templateData).Decode(&kubeResource)
 	if err != nil {
 		return "", fmt.Errorf("ToYAML: could not convert replaced template into Deployment: %s", err)
 	}

--- a/pkg/kube/secret.go
+++ b/pkg/kube/secret.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/vault"
 	corev1 "k8s.io/api/core/v1"
@@ -62,25 +61,11 @@ func (d *SecretTemplate) Replace() error {
 
 // Ensures the replacements for the Secret data are in the right format
 func secretReplacement(key, value string, vaultData map[string]interface{}) (_ interface{}, err []error) {
-	var byteData []byte
 	res, err := genericReplacement(key, value, vaultData)
 
 	// We have to return []byte for k8s secrets,
 	// so we convert whatever is in Vault
-	switch res.(type) {
-	case int:
-		{
-			byteData = []byte(strconv.Itoa(res.(int)))
-		}
-	case bool:
-		{
-			byteData = []byte(strconv.FormatBool(res.(bool)))
-		}
-	case string:
-		{
-			byteData = []byte(res.(string))
-		}
-	}
+	byteData := []byte(stringify(res))
 
 	return byteData, err
 }

--- a/pkg/kube/secret.go
+++ b/pkg/kube/secret.go
@@ -1,15 +1,12 @@
 package kube
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/vault"
 	corev1 "k8s.io/api/core/v1"
-	k8yamldecoder "k8s.io/apimachinery/pkg/util/yaml"
 	k8yaml "sigs.k8s.io/yaml"
 )
 
@@ -90,10 +87,8 @@ func secretReplacement(key, value string, vaultData map[string]interface{}) (_ i
 
 // ToYAML seralizes the completed template into YAML to be consumed by Kubernetes
 func (d *SecretTemplate) ToYAML() (string, error) {
-	jsondata, _ := json.Marshal(d.templateData)
-	decoder := k8yamldecoder.NewYAMLOrJSONDecoder(bytes.NewReader(jsondata), 1000)
 	kubeResource := corev1.Secret{}
-	err := decoder.Decode(&kubeResource)
+	err := kubeResourceDecoder(&d.templateData).Decode(&kubeResource)
 	if err != nil {
 		return "", fmt.Errorf("ToYAML: could not convert replaced template into Secret: %s", err)
 	}

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -1,5 +1,11 @@
 package kube
 
+import (
+	"fmt"
+
+	"github.com/IBM/argocd-vault-plugin/pkg/vault"
+)
+
 // Template is created from YAML files for Kubernetes resources (manifests) that contain
 // <placeholders>'s. Templates can be replaced by replacing the <placeholders>
 // with values from Vault. They can be serialized back to YAML for usage by Kubernetes.
@@ -13,4 +19,39 @@ type Resource struct {
 	templateData      map[string]interface{} // The template as read from YAML
 	replacementErrors []error                // Any errors encountered in performing replacements
 	vaultData         map[string]interface{} // The data to replace with, from Vault
+}
+
+// CreateTemplate will attempt to create the appropriate Template from a Kubernetes manifest.
+// It will throw an error for unsupported manifest Kind's
+func CreateTemplate(manifest map[string]interface{}, vault vault.VaultType) (Template, error) {
+	switch manifest["kind"] {
+	case "Deployment":
+		{
+			template, err := NewDeploymentTemplate(manifest, vault)
+			if err != nil {
+				return nil, err
+			}
+			return template, nil
+		}
+	case "Secret":
+		{
+			template, err := NewSecretTemplate(manifest, vault)
+			if err != nil {
+				return nil, err
+			}
+			return template, nil
+		}
+	case "ConfigMap":
+		{
+			template, err := NewConfigMapTemplate(manifest, vault)
+			if err != nil {
+				return nil, err
+			}
+			return template, nil
+		}
+	default:
+		{
+			return nil, fmt.Errorf("unsupported kind: %s", manifest["kind"])
+		}
+	}
 }

--- a/pkg/kube/template_test.go
+++ b/pkg/kube/template_test.go
@@ -94,3 +94,45 @@ func TestToYAML_Secret(t *testing.T) {
 		t.Fatalf("expected YAML:\n%s\nbut got:\n%s\n", expected, actual)
 	}
 }
+
+func TestToYAML_ConfigMap(t *testing.T) {
+	d := ConfigMapTemplate{
+		Resource{
+			templateData: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "default",
+					"name":      "<name>",
+				},
+				"data": map[string]interface{}{
+					"MY_NONSECRET_STRING": "<string>",
+					"MY_NONSECRET_NUM":    "<num>",
+				},
+			},
+			vaultData: map[string]interface{}{
+				"name":   "my-app",
+				"string": "foo",
+				"num":    5,
+			},
+		},
+	}
+
+	err := d.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expectedData, err := ioutil.ReadFile("../../fixtures/output/small-configmap.yaml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := string(expectedData)
+	actual, err := d.ToYAML()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected YAML:\n%s\nbut got:\n%s\n", expected, actual)
+	}
+}

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -1,37 +1,15 @@
 package kube
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
 
-	"github.com/IBM/argocd-vault-plugin/pkg/vault"
+	k8yamldecoder "k8s.io/apimachinery/pkg/util/yaml"
 )
-
-// CreateTemplate will attempt to create the appropriate Template from a Kubernetes manifest.
-// It will throw an error for unsupported manifest Kind's
-func CreateTemplate(manifest map[string]interface{}, vault vault.VaultType) (Template, error) {
-	switch manifest["kind"] {
-	case "Deployment":
-		{
-			template, err := NewDeploymentTemplate(manifest, vault)
-			if err != nil {
-				return nil, err
-			}
-			return template, nil
-		}
-	case "Secret":
-		{
-			template, err := NewSecretTemplate(manifest, vault)
-			if err != nil {
-				return nil, err
-			}
-			return template, nil
-		}
-	}
-	return nil, fmt.Errorf("unsupported kind: %s", manifest["kind"])
-}
 
 func replaceInner(
 	r *Resource,
@@ -102,4 +80,10 @@ func genericReplacement(key, value string, vaultData map[string]interface{}) (_ 
 		return nonStringReplacement, err
 	}
 	return string(res), err
+}
+
+func kubeResourceDecoder(data *map[string]interface{}) *k8yamldecoder.YAMLOrJSONDecoder {
+	jsondata, _ := json.Marshal(data)
+	decoder := k8yamldecoder.NewYAMLOrJSONDecoder(bytes.NewReader(jsondata), 1000)
+	return decoder
 }

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	k8yamldecoder "k8s.io/apimachinery/pkg/util/yaml"
@@ -80,6 +81,23 @@ func genericReplacement(key, value string, vaultData map[string]interface{}) (_ 
 		return nonStringReplacement, err
 	}
 	return string(res), err
+}
+
+func stringify(input interface{}) string {
+	switch input.(type) {
+	case int:
+		{
+			return strconv.Itoa(input.(int))
+		}
+	case bool:
+		{
+			return strconv.FormatBool(input.(bool))
+		}
+	default:
+		{
+			return input.(string)
+		}
+	}
 }
 
 func kubeResourceDecoder(data *map[string]interface{}) *k8yamldecoder.YAMLOrJSONDecoder {


### PR DESCRIPTION
### Description

- Adds support for templated `ConfigMap` YAMLs
- Moves `CreateTemplate()` from util.go to template.go since that makes more sense and clearly shows what kinds of Templates we currently support
- Deduplicate code to decode a replaced template into a Kubernetes resource struct

### Checklist
Please make sure that your PR fulfills the following requirements: 
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
