### PR TITLE
feat: Support for Service resource and multi-document YAML files

### DIFF
--- a/fixtures/input/nonempty/full.yaml
+++ b/fixtures/input/nonempty/full.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: <name>
+  namespace: <namespace>
+  labels:
+    app: <name>
+spec:
+  selector:
+    app: <name>
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: <target-port>
+  type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <name>
+  namespace: <namespace>
+  labels:
+    app: <name>
+    version: <version>
+spec:
+  selector:
+    matchLabels:
+      app: <name>
+  replicas: <replicas>
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      name: <name>
+      labels:
+        app: <name>
+    spec:
+      containers:
+      - name: <name>
+        image: foo.com/<name>:<tag>
+        imagePullPolicy: Always

--- a/fixtures/output/small-service.yaml
+++ b/fixtures/output/small-service.yaml
@@ -1,0 +1,11 @@
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: my-app
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    targetPort: 0
+  selector:
+    app: my-app

--- a/pkg/kube/service.go
+++ b/pkg/kube/service.go
@@ -1,0 +1,57 @@
+package kube
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/IBM/argocd-vault-plugin/pkg/vault"
+	corev1 "k8s.io/api/core/v1"
+	k8yaml "sigs.k8s.io/yaml"
+)
+
+// ServiceTemplate is the template for Kubernetes Services
+type ServiceTemplate struct {
+	Resource
+}
+
+// NewServiceTemplate returns a *ServiceTemplate given the template's data, and a VaultType
+func NewServiceTemplate(template map[string]interface{}, vault vault.VaultType) (*ServiceTemplate, error) {
+	path := os.Getenv("VAULT_PATH_PREFIX")
+	data, err := vault.GetSecrets(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceTemplate{
+		Resource{
+			templateData: template,
+			vaultData:    data,
+		},
+	}, nil
+}
+
+// Replace will replace the <placeholders> in the template's data with values from Vault.
+// It will return an aggregrate of any errors encountered during the replacements
+func (d *ServiceTemplate) Replace() error {
+	replaceInner(&d.Resource, &d.templateData, genericReplacement)
+	if len(d.replacementErrors) != 0 {
+
+		// TODO format multiple errors nicely
+		return fmt.Errorf("Replace: could not replace all placeholders in ServiceTemplate: %s", d.replacementErrors)
+	}
+	return nil
+}
+
+// ToYAML seralizes the completed template into YAML to be consumed by Kubernetes
+func (d *ServiceTemplate) ToYAML() (string, error) {
+	kubeResource := corev1.Service{}
+	err := kubeResourceDecoder(&d.templateData).Decode(&kubeResource)
+	if err != nil {
+		return "", fmt.Errorf("ToYAML: could not convert replaced template into Service: %s", err)
+	}
+	res, err := k8yaml.Marshal(&kubeResource)
+	if err != nil {
+		return "", fmt.Errorf("ToYAML: could not export Service into YAML: %s", err)
+	}
+	return string(res), nil
+}

--- a/pkg/kube/service.go
+++ b/pkg/kube/service.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/vault"
 	corev1 "k8s.io/api/core/v1"
@@ -16,8 +15,7 @@ type ServiceTemplate struct {
 
 // NewServiceTemplate returns a *ServiceTemplate given the template's data, and a VaultType
 func NewServiceTemplate(template map[string]interface{}, vault vault.VaultType) (*ServiceTemplate, error) {
-	path := os.Getenv("VAULT_PATH_PREFIX")
-	data, err := vault.GetSecrets(path)
+	data, err := vault.GetSecrets("/service")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -33,6 +33,14 @@ func CreateTemplate(manifest map[string]interface{}, vault vault.VaultType) (Tem
 			}
 			return template, nil
 		}
+	case "Service":
+		{
+			template, err := NewServiceTemplate(manifest, vault)
+			if err != nil {
+				return nil, err
+			}
+			return template, nil
+		}
 	case "Secret":
 		{
 			template, err := NewSecretTemplate(manifest, vault)

--- a/pkg/kube/template_test.go
+++ b/pkg/kube/template_test.go
@@ -53,6 +53,54 @@ func TestToYAML_Deployment(t *testing.T) {
 	}
 }
 
+func TestToYAML_Service(t *testing.T) {
+	d := ServiceTemplate{
+		Resource{
+			templateData: map[string]interface{}{
+				"kind": "Service",
+				"metadata": map[string]interface{}{
+					"namespace": "default",
+					"name":      "<name>",
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"app": "<name>",
+					},
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port": "<port>",
+						},
+					},
+				},
+			},
+			vaultData: map[string]interface{}{
+				"name": "my-app",
+				"port": 8080,
+			},
+		},
+	}
+
+	err := d.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expectedData, err := ioutil.ReadFile("../../fixtures/output/small-service.yaml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := string(expectedData)
+	actual, err := d.ToYAML()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected YAML:\n%s\nbut got:\n%s\n", expected, actual)
+	}
+}
+
 func TestToYAML_Secret(t *testing.T) {
 	d := SecretTemplate{
 		Resource{
@@ -134,5 +182,48 @@ func TestToYAML_ConfigMap(t *testing.T) {
 
 	if !strings.Contains(actual, expected) {
 		t.Fatalf("expected YAML:\n%s\nbut got:\n%s\n", expected, actual)
+	}
+}
+
+func TestToYAML_DeploymentBad(t *testing.T) {
+	d := DeploymentTemplate{
+		Resource{
+			templateData: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "default",
+					"name":      "<name>",
+				},
+				"spec": map[string]interface{}{
+					"replicas":        "<replicas>",
+					"minReadySeconds": "<minReadySeconds>",
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"app": "<name>",
+							},
+						},
+					},
+				},
+			},
+			vaultData: map[string]interface{}{
+				"replicas":        3,
+				"minReadySeconds": "one hundred",
+				"name":            "!!@#@.---.",
+			},
+		},
+	}
+
+	err := d.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	actual, err := d.ToYAML()
+	if err == nil {
+		t.Fatalf("Expected ToYAML error but got %s", actual)
+	}
+
+	if !strings.Contains(err.Error(), "DeploymentSpec.spec.minReadySeconds of type int32") {
+		t.Fatalf("Expected error with minReadySeconds, got: %s", err.Error())
 	}
 }

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	k8yamldecoder "k8s.io/apimachinery/pkg/util/yaml"
+	k8yaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func replaceInner(
@@ -100,8 +100,8 @@ func stringify(input interface{}) string {
 	}
 }
 
-func kubeResourceDecoder(data *map[string]interface{}) *k8yamldecoder.YAMLOrJSONDecoder {
+func kubeResourceDecoder(data *map[string]interface{}) *k8yaml.YAMLToJSONDecoder {
 	jsondata, _ := json.Marshal(data)
-	decoder := k8yamldecoder.NewYAMLOrJSONDecoder(bytes.NewReader(jsondata), 1000)
+	decoder := k8yaml.NewYAMLToJSONDecoder(bytes.NewReader(jsondata))
 	return decoder
 }


### PR DESCRIPTION
### Description

Add support for Kubernetes services and multi-doc YAML like this:
```
apiVersion: v1
kind: Service
metadata:
  name: <name>
  namespace: <namespace>
  labels:
    app: <name>
spec:
  selector:
    app: <name>
  ports:
    - protocol: TCP
      name: http
      port: 80
      targetPort: <target-port>
  type: NodePort
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: <name>
  namespace: <namespace>
  labels:
    app: <name>
    version: <version>
spec:
  selector:
    matchLabels:
      app: <name>
  replicas: <replicas>
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
  minReadySeconds: 5
  revisionHistoryLimit: 10
  template:
    metadata:
      name: <name>
      labels:
        app: <name>
    spec:
      containers:
      - name: <name>
        image: foo.com/<name>:<tag>
        imagePullPolicy: Always
```

- Refactors the resource decode function to not need to guess if YAML or JSON, and instead assumes YAML always

### Checklist
Please make sure that your PR fulfills the following requirements: 
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
