### PR TITLE
fix: Set token before writing to file, silent fail if error

### DIFF
--- a/pkg/vault/util.go
+++ b/pkg/vault/util.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -51,10 +52,13 @@ func Login(vaultClient VaultType, vaultConfig *Config) error {
 }
 
 // SetToken TODO
-func SetToken(client *Client, token string) error {
+func SetToken(client *Client, token string) {
+	// We want to set the token first
+	client.VaultAPIClient.SetToken(token)
+
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return err
+		fmt.Printf("Could not access home directory, will need to login to Vault on subsequent runs: %s", err.Error())
 	}
 
 	path := filepath.Join(home, ".avp")
@@ -68,10 +72,6 @@ func SetToken(client *Client, token string) error {
 	file, _ := json.MarshalIndent(data, "", " ")
 	err = ioutil.WriteFile(filepath.Join(path, "config.json"), file, 0644)
 	if err != nil {
-		return err
+		fmt.Printf("Could not write token to file, will need to login to Vault on subsequent runs: %s", err.Error())
 	}
-
-	client.VaultAPIClient.SetToken(token)
-
-	return nil
 }

--- a/pkg/vault/utils_test.go
+++ b/pkg/vault/utils_test.go
@@ -56,12 +56,9 @@ func TestSetToken(t *testing.T) {
 		VaultAPIClient: cluster.Cores[0].Client,
 	}
 
-	err := vault.SetToken(vc, "token")
-	if err != nil {
-		t.Errorf("expected token to be written, got: %s.", err)
-	}
+	vault.SetToken(vc, "token")
 
-	err = removeToken()
+	err := removeToken()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version is the argocd-vault-plugin version.
-	Version = "v0.2.0"
+	Version = "v0.2.1"
 )


### PR DESCRIPTION
### Description
Fix issue with token not being set if writing config fails

**Fixes:** #38 

### Checklist
Please make sure that your PR fulfills the following requirements: 
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
