### PR TITLE
fix: Handle YAMLs with non-placeholder strings properly

### DIFF
--- a/fixtures/output/small-secret2.yaml
+++ b/fixtures/output/small-secret2.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-app
+  namespace: default
+secretData:
+  MY_SECRET_NUM: 5
+  MY_SECRET_STRING: foo

--- a/fixtures/output/small-secret3.yaml
+++ b/fixtures/output/small-secret3.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  MY_LEAKED_SECRET: cGFzc3dvcmQ=
+  MY_SECRET_NUM: NQ==
+  MY_SECRET_STRING: Zm9v
+kind: Secret
+metadata:
+  name: my-app
+  namespace: default

--- a/fixtures/output/small-secret4.yaml
+++ b/fixtures/output/small-secret4.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  MY_LEAKED_SECRET: cGFzc3dvcmQ=
+kind: Secret
+metadata:
+  name: my-app
+  namespace: default

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -102,8 +102,9 @@ func configReplacement(key, value string, vaultData map[string]interface{}) (int
 	return stringify(res), err
 }
 
-// Replace will replace the <placeholders> in the template's data with values from Vault.
+// secretReplace will replace the <placeholders> in the template's data with values from Vault.
 // It will return an aggregrate of any errors encountered during the replacements
+// It will ensure that `<placeholder>`'s in `.data` are base64 encoded
 func (t *Template) secretReplace() error {
 
 	// Replace metadata normally

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -13,6 +13,7 @@ import (
 type Resource struct {
 	Kind              string
 	TemplateData      map[string]interface{} // The template as read from YAML
+	replaceable       bool                   // Whether there are placeholders to replace or not; if false, VaultData will be nil
 	replacementErrors []error                // Any errors encountered in performing replacements
 	VaultData         map[string]interface{} // The data to replace with, from Vault
 }
@@ -42,24 +43,37 @@ func NewTemplate(template map[string]interface{}, backend types.Backend, prefix 
 		kvVersion = kv
 	}
 
-	data, err := backend.GetSecrets(path, kvVersion)
-	if err != nil {
-		return nil, err
+	// Only worry about getting Vault secrets for templates with <placeholder>'s
+	replaceable := replaceableInner(&template)
+	var data map[string]interface{}
+	if replaceable {
+		data, err = backend.GetSecrets(path, kvVersion)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Template{
 		Resource{
 			Kind:         obj.GetKind(),
 			TemplateData: template,
+			replaceable:  replaceable,
 			VaultData:    data,
 		},
 	}, nil
 }
 
-// Replace will replace the <placeholders> in the template's data with values from Vault.
-// It will return an aggregrate of any errors encountered during the replacements
+// Replace will replace the <placeholders> in the Template's data with values from Vault.
+// It will return an aggregrate of any errors encountered during the replacements.
+// For both non-Secret resources and Secrets with <placeholder>'s in `secretData`, the value in Vault is emitted as-is
+// For Secret's with <placeholder>'s in `.data`, the value in Vault is emitted as base64
+// For any hard-coded strings that aren't <placeholder>'s, the string is emitted as-is
 func (t *Template) Replace() error {
 	var replacerFunc func(string, string, map[string]interface{}) (interface{}, []error)
+
+	if !t.replaceable {
+		return nil
+	}
 
 	switch t.Kind {
 	case "Secret":
@@ -103,15 +117,30 @@ func (t *Template) secretReplace() error {
 		}
 	}
 
-	// Replace the actual secrets with []byte's
+	// Replace secretData normally
+	secretData, ok := t.TemplateData["secretData"].(map[string]interface{})
+	if ok {
+		replaceInner(&t.Resource, &secretData, genericReplacement)
+		if len(t.replacementErrors) != 0 {
+
+			// TODO format multiple errors nicely
+			return fmt.Errorf("Replace: could not replace all placeholders in SecretTemplate secretData: %s", t.replacementErrors)
+		}
+	}
+
+	// Replace <placeholder>'d Secret.data with []byte's
 	data, ok := t.TemplateData["data"].(map[string]interface{})
 	if ok {
 		replaceInner(&t.Resource, &data, func(key, value string, vaultData map[string]interface{}) (_ interface{}, err []error) {
 			res, err := genericReplacement(key, value, vaultData)
+
 			// We have to return []byte for k8s secrets,
-			// so we convert whatever is in Vault
-			byteData := []byte(stringify(res))
-			return byteData, err
+			// so we convert everything that came from Vault
+			// Strings hardcoded in the Secret.data are assumed to be base64 encoded already
+			if placeholder.Match([]byte(value)) {
+				return []byte(stringify(res)), err
+			}
+			return res, err
 		})
 
 		if len(t.replacementErrors) != 0 {


### PR DESCRIPTION
### Description

Previously, the plugin would attempt to always get secrets from Vault for each manifest, even if there were no secrets in Vault for it. Now, the logic is as follows:

- If there are placeholders in the manifest template, try to get secrets from Vault, and return any appropriate error during that and during replacement
- Otherwise, skip reading from Vault, and emit the manifest as-is during replacement

Fixing this also introduced a new problem with `Secret`'s, since things under `data` need to be in base64 format, whereas everything else doesn't. So we add the following logic:

- If a `Secret.data` key has a `<placeholder>` value, we emit it's replacement base64 encoded. The expectation therefore is that the user puts data into Vault exactly as they want it loaded _into their app_
- Otherwise, we emit it as-is, meaning the user should hard-code any `Secret.data` values as base64 encoded. This makes for a proper GitOps experience

Anything in Secret that isn't in `data` is also emitted as-is (`metadata`, `secretData` fields)

**Fixes:** #54 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
