### PR TITLE
fixed k8s authtype reversed args

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,8 +95,8 @@ func New(viper *viper.Viper, httpClient *http.Client) (*Config, error) {
 					tokenPath = viper.GetString("K8S_TOKEN_PATH")
 				}
 				auth = vault.NewK8sAuth(
-					viper.GetString("K8S_MOUNT_POINT"),
 					viper.GetString("K8S_ROLE"),
+					viper.GetString("K8S_MOUNT_POINT"),
 					tokenPath,
 				)
 			} else {


### PR DESCRIPTION
### Description
When the K8sAuth struct is constructed in config.go, the arguments passed to NewK8sAuth for K8S_ROLE and K8S_MOUNT_POINT has been seemingly accidentally reversed.

This PR swaps them, so that they are passed in the correct order.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
