### PR TITLE
fix: Increase timeout on DefaultHttpClient to 60s

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -100,7 +100,7 @@ func DefaultHttpClient() *http.Client {
 	}
 
 	var httpClient = &http.Client{
-		Timeout:   10 * time.Second,
+		Timeout:   60 * time.Second,
 		Transport: transport,
 	}
 


### PR DESCRIPTION
### Description
Increase the timeout for the DefaultHttpClient to 60s.

**Fixes:** https://github.com/IBM/argocd-vault-plugin/issues/97

### Checklist
Please make sure that your PR fulfills the following requirements:
- [X] Reviewed the guidelines for contributing to this repository
- [X] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [X] Tests for the changes have been updated
- [X] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
