### PR TITLE
Various Features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 .chglog
 test
 cover.out
+.idea

--- a/pkg/backends/vault.go
+++ b/pkg/backends/vault.go
@@ -3,6 +3,7 @@ package backends
 import (
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/types"
 	"github.com/hashicorp/vault/api"
@@ -37,7 +38,14 @@ func (v *Vault) Login() error {
 
 // GetSecrets gets secrets from vault and returns the formatted data
 func (v *Vault) GetSecrets(path, kvVersion string) (map[string]interface{}, error) {
-	secret, err := v.VaultClient.Logical().Read(path)
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	data := parsed.Query()
+	parsed.RawQuery = ""
+	secret, err := v.VaultClient.Logical().ReadWithData(parsed.String(), data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -35,6 +35,31 @@ func assertFailedReplacement(actual, expected *Resource, t *testing.T) {
 	}
 }
 
+func TestGenericReplacement_simpleEncodedString(t *testing.T) {
+	dummyResource := Resource{
+		TemplateData: map[string]interface{}{
+			"namespace": "PG5hbWVzcGFjZT4K",
+		},
+		VaultData: map[string]interface{}{
+			"namespace": "default",
+		},
+	}
+
+	replaceInner(&dummyResource, &dummyResource.TemplateData, genericReplacement)
+
+	expected := Resource{
+		TemplateData: map[string]interface{}{
+			"namespace": "ZGVmYXVsdAo=",
+		},
+		VaultData: map[string]interface{}{
+			"namespace": "default",
+		},
+		replacementErrors: []error{},
+	}
+
+	assertSuccessfulReplacement(&dummyResource, &expected, t)
+}
+
 func TestGenericReplacement_simpleString(t *testing.T) {
 	dummyResource := Resource{
 		TemplateData: map[string]interface{}{


### PR DESCRIPTION
### Description
**Support base64 encoded templates (ie: Output of kustomize secret generator)**

Given a Vault secret located at `kv/data/somesecret` with the following content:
```
{ "foo": "foo-value", "bar":"bar-value" }
```

and the following `kustomization.yaml` file in a directory named `example`...
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

secretGenerator:
  - name: test
    literals:
      - 'foo=<foo>'
      - 'bar=<bar>'
    options:
      annotations:
        avp_path: 'kv/data/foo'
```

Running `kustomize build example`, would produce the following secret. Note, it is not possible to output non base64 encoded content to `stringData` with kustomize.
```
apiVersion: v1
data:
  bar: PGJhcj4=
  foo: PGZvbz4=
kind: Secret
metadata:
  annotations:
    avp_path: kv/data/foo
  name: test-k29d8kmc86
type: Opaque
```

When rendered with `argocd-vault-plugin generate`, the following secret would be produced:
```
apiVersion: v1
data:
  bar: YmFyLXZhbHVl # bar-value
  foo: Zm9vLXZhbHVl # foo-value
kind: Secret
metadata:
  annotations:
    avp_path: kv/data/foo
  name: test-k29d8kmc86
type: Opaque
```

**Add Vault path query string support (ie: kv/data/foo?version=2)**
```
apiVersion: v1
kind: Secret
metadata:
  name: test
  annotations:
    avp_path: "kv/data/somesecret?version=7" # Explicitly fetch version 7 of the secret
type: Opaque
stringData:
    foo: <Some-Key-From-Version-7>
```

**Add support to auto template all available secret keys (via annotation avp_all_keys_to: data|stringData)**

Given a Vault secret located at `kv/data/somesecret` with the following content:
```
{ "foo": "foo-value", "bar":"bar-value" }
```

And the following `Secret`
```
apiVersion: v1
kind: Secret
metadata:
  annotations:
    avp_path: kv/data/somesecret
    avp_all_keys_to: stringData  # Include all keys in kv/data/somesecret
  name: test
type: Opaque
```

The following secret would be produced
```
apiVersion: v1
kind: Secret
metadata:
  annotations:
    avp_path: kv/data/somesecret
    avp_all_keys_to: stringData  # supports stringData or data
  name: test
stringData:
  foo: "foo-value"
  bar: "bar-value"
type: Opaque
```

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
