### PR TITLE
fix: Remove unnecessary panics on replace

### DIFF
--- a/fixtures/output/small-custom-resource.yaml
+++ b/fixtures/output/small-custom-resource.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  A_SEQUENCE:
+  - 1
+  - two
+  A_SHELL_SCRIPT: bx login --apikey 123
+  A_YAML: |-
+    username: user
+    password: pass
+kind: SomeCustomResource
+metadata:
+  name: my-app
+  namespace: default

--- a/pkg/kube/template_test.go
+++ b/pkg/kube/template_test.go
@@ -257,6 +257,58 @@ func TestToYAML_Secret_PlaceholderedData(t *testing.T) {
 	}
 }
 
+func TestToYAML_CRD_PlaceholderedData(t *testing.T) {
+	d := Template{
+		Resource{
+			Kind: "SomeCustomResource",
+			TemplateData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "SomeCustomResource",
+				"metadata": map[string]interface{}{
+					"namespace": "default",
+					"name":      "<name>",
+				},
+				"data": map[string]interface{}{
+					"A_SEQUENCE": []interface{}{
+						1,
+						"<two>",
+					},
+					"A_YAML": "username: <username>\npassword: <password>",
+					"A_SHELL_SCRIPT": "bx login --apikey <apikey>",
+				},
+			},
+			replaceable: true,
+			VaultData: map[string]interface{}{
+				"name":   "my-app",
+				"two": "two",
+				"username": "user",
+				"password": "pass",
+				"apikey": "123",
+			},
+		},
+	}
+
+	err := d.Replace()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expectedData, err := ioutil.ReadFile("../../fixtures/output/small-custom-resource.yaml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	expected := string(expectedData)
+	actual, err := d.ToYAML()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected YAML:\n%s\nbut got:\n%s\n", expected, actual)
+	}
+}
+
 func TestToYAML_Secret_HardcodedData(t *testing.T) {
 	d := Template{
 		Resource{

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -17,13 +17,12 @@ var placeholder, _ = regexp.Compile(`(?mU)<(.*)>`)
 // replaceableInner recurses through the given map and returns true if _any_ value is a `<placeholder>` string
 func replaceableInner(node *map[string]interface{}) bool {
 	obj := *node
-
 	for _, value := range obj {
 		valueType := reflect.ValueOf(value).Kind()
 		if valueType == reflect.Map {
 			inner, ok := value.(map[string]interface{})
 			if !ok {
-				panic(fmt.Sprintf("Deserialized YAML node is non map[string]interface{}"))
+				continue
 			}
 			if replaceableInner(&inner) {
 				return true
@@ -43,10 +42,6 @@ func replaceableInner(node *map[string]interface{}) bool {
 						if placeholder.Match([]byte(elm.(string))) {
 							return true
 						}
-					}
-				default:
-					{
-						panic(fmt.Sprintf("Deserialized YAML list node is non map[string]interface{} nor string"))
 					}
 				}
 			}
@@ -73,7 +68,7 @@ func replaceInner(
 		if valueType == reflect.Map {
 			inner, ok := value.(map[string]interface{})
 			if !ok {
-				panic(fmt.Sprintf("Deserialized YAML node is non map[string]interface{}"))
+				continue
 			}
 			replaceInner(r, &inner, replacerFunc)
 		} else if valueType == reflect.Slice {
@@ -92,10 +87,6 @@ func replaceInner(
 							r.replacementErrors = append(r.replacementErrors, err...)
 						}
 						value.([]interface{})[idx] = replacement
-					}
-				default:
-					{
-						panic(fmt.Sprintf("Deserialized YAML list node is non map[string]interface{} nor string"))
 					}
 				}
 			}


### PR DESCRIPTION
### Description

- Removes unnecessary panics by skipping over any YAML nodes that are ineligible for replacement; i.e, anything that is not a `[]string`, `map[string]interface{}`, or `string`

**Fixes:** #63 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
