### PR TITLE
fix: Set VAULT_ variables from Viper and display replace errors better

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM/argocd-vault-plugin
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.34.28 // indirect
+	github.com/aws/aws-sdk-go v1.34.28
 	github.com/frankban/quicktest v1.11.2 // indirect
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/golang/snappy v0.0.2 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,7 +155,7 @@ func readConfigOrSecret(secretName, configPath string, v *viper.Viper) error {
 		}
 	}
 
-	for k, v := range viper.AllSettings() {
+	for k, v := range v.AllSettings() {
 		if strings.HasPrefix(k, "vault") {
 			var value string
 			switch v.(type) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,14 +155,14 @@ func readConfigOrSecret(secretName, configPath string, v *viper.Viper) error {
 		}
 	}
 
-	for k, v := range v.AllSettings() {
+	for k, viperValue := range v.AllSettings() {
 		if strings.HasPrefix(k, "vault") {
 			var value string
-			switch v.(type) {
+			switch viperValue.(type) {
 			case bool:
-				value = strconv.FormatBool(v.(bool))
+				value = strconv.FormatBool(viperValue.(bool))
 			default:
-				value = v.(string)
+				value = viperValue.(string)
 			}
 			os.Setenv(strings.ToUpper(k), value)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -185,3 +185,15 @@ func TestNewConfigMissingParameter(t *testing.T) {
 	}
 
 }
+
+func TestExternalConfig(t *testing.T) {
+	os.Setenv("AVP_TYPE", "vault")
+	viper := viper.New()
+	viper.SetDefault("VAULT_ADDR", "http://my-vault:8200/")
+	config.New(viper, &config.Options{})
+	if os.Getenv("VAULT_ADDR") != "http://my-vault:8200/" {
+		t.Errorf("expected VAULT_ADDR env to be set from external config, was instead: %s", os.Getenv("VAULT_ADDR"))
+	}
+	os.Unsetenv("AVP_TYPE")
+	os.Unsetenv("VAULT_ADDR")
+}

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -65,8 +66,11 @@ func (t *Template) Replace() error {
 
 	replaceInner(&t.Resource, &t.TemplateData, replacerFunc)
 	if len(t.replacementErrors) != 0 {
-		// TODO format multiple errors nicely
-		return fmt.Errorf("Replace: could not replace all placeholders in Template: %s", t.replacementErrors)
+		errMessages := make([]string, len(t.replacementErrors))
+		for idx, err := range(t.replacementErrors) {
+			errMessages[idx] = err.Error()
+		}
+		return fmt.Errorf("Replace: could not replace all placeholders in Template:\n%s", strings.Join(errMessages, "\n"))
 	}
 	return nil
 }

--- a/pkg/kube/template_test.go
+++ b/pkg/kube/template_test.go
@@ -21,6 +21,41 @@ func (v *MockVault) GetSecrets(path string, annotations map[string]string) (map[
 	return map[string]interface{}{}, nil
 }
 
+func TestToYAML_Missing_Placeholders(t *testing.T) {
+	d := Template{
+		Resource{
+			Kind: "Secret",
+			TemplateData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						types.AVPPathAnnotation: "path",
+					},
+					"namespace": "default",
+					"name":      "some-resource",
+				},
+				"stringData": map[string]interface{}{
+					"MY_SECRET_STRING": "<string>",
+				},
+			},
+			Data: map[string]interface{}{
+			},
+		},
+	}
+
+	err := d.Replace()
+	if err == nil {
+		t.Fatalf(err.Error())
+	}
+	
+	expectedErr := "Replace: could not replace all placeholders in Template:\nreplaceString: missing Vault value for placeholder string in string MY_SECRET_STRING: <string>"
+
+	if expectedErr != err.Error() {
+		t.Fatalf("expected error \n%s but got error \n%s", expectedErr, err.Error())
+	}
+}
+
 func TestNewTemplate(t *testing.T) {
 	t.Run("will GetSecrets for placeholder'd YAML", func(t *testing.T) {
 		mv := MockVault{}


### PR DESCRIPTION
### Description

Fixes the other problems discovered in testing #115:

- Sets `VAULT_` variables from Viper-read config file or k8s secret
- Prints the replacement errors newline separated to make them easier to read


### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
