### PR TITLE
feat: decode base64 encoded placeholders in secrets

### DIFF
--- a/fixtures/input/nonempty/secret_path_base64.yaml
+++ b/fixtures/input/nonempty/secret_path_base64.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+  name: example-secret-base64
+  namespace: default
+type: Opaque
+data:
+  SECRET_VAR: PHBhdGg6c2VjcmV0L3Rlc3Rpbmcjc2VjcmV0LXZhci12YWx1ZT4=

--- a/fixtures/output/all.yaml
+++ b/fixtures/output/all.yaml
@@ -119,3 +119,14 @@ metadata:
   namespace: default
 type: Opaque
 ---
+apiVersion: v1
+data:
+  SECRET_VAR: dGVzdC1wYXNzd29yZA==
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+  name: example-secret-base64
+  namespace: default
+type: Opaque
+---

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -60,6 +60,8 @@ func (t *Template) Replace() error {
 	switch t.Kind {
 	case "ConfigMap":
 		replacerFunc = configReplacement
+	case "Secret":
+		replacerFunc = secretReplacement
 	default:
 		replacerFunc = genericReplacement
 	}

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -133,6 +134,15 @@ func configReplacement(key, value string, resource Resource) (interface{}, []err
 
 	// configMap data values must be strings
 	return stringify(res), err
+}
+
+func secretReplacement(key, value string, resource Resource) (interface{}, []error) {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err == nil && placeholder.Match(decoded) {
+		return genericReplacement(key, string(decoded), resource)
+	}
+
+	return genericReplacement(key, value, resource)
 }
 
 func stringify(input interface{}) string {


### PR DESCRIPTION
### Description

Checks if secret placeholders are base64 encoded before replacing.

**Fixes:** https://github.com/IBM/argocd-vault-plugin/issues/124

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information

I'm open to suggestions on how to document this.