### PR TITLE
fix: remove avp prefix from aws env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,9 +362,9 @@ AVP_IBM_API_KEY: Your IBM Cloud API Key
 ##### AWS Authentication
 These are the required parameters parameters for AWS:
 ```
-AVP_TYPE: awssecretmanager
-AVP_AWS_ACCESS_KEY_ID: Your AWS Access Key ID
-AVP_AWS_SECRET_ACCESS_KEY: Your AWS Secret Access Key
+AVP_TYPE: awssecretsmanager
+AWS_ACCESS_KEY_ID: Your AWS Access Key ID
+AWS_SECRET_ACCESS_KEY: Your AWS Secret Access Key
 ```
 
 ## Configuration
@@ -414,7 +414,7 @@ We support all Vault Environment Variables listed [here](https://www.vaultprojec
 | --------------- | ----------- | ----- |
 | AVP_TYPE           | The type of Vault backend  | Supported values: `vault`, `ibmsecretsmanager` and `awssecretsmanager` |
 | AVP_KV_VERSION    | The vault secret engine  | Supported values: `1` and `2` (defaults to 2). KV_VERSION will be ignored if the `avp.kubernetes.io/kv-version` annotation is present in a YAML resource.|
-| AVP_AUTH_TYPE      | The type of authentication | Supported values: vault: `approle, github`   secretmanager: `iam` |
+| AVP_AUTH_TYPE      | The type of authentication | Supported values: vault: `approle, github, k8s`   ibmsecretsmanager: `iam` |
 | AVP_GITHUB_TOKEN   | Github token               | Required with `AUTH_TYPE` of `github` |
 | AVP_ROLE_ID        | Vault AppRole Role_ID      | Required with `AUTH_TYPE` of `approle` |
 | AVP_SECRET_ID      | Vault AppRole Secret_ID    | Required with `AUTH_TYPE` of `approle` |
@@ -422,9 +422,9 @@ We support all Vault Environment Variables listed [here](https://www.vaultprojec
 | AVP_K8S_ROLE       | Kuberentes Auth Role      | Required with `AUTH_TYPE` of `k8s` |
 | AVP_K8S_TOKEN_PATH | Path to JWT for Kubernetes Auth  | Optional for `AUTH_TYPE` of `k8s` defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token` |
 | AVP_IBM_API_KEY    | IBM Cloud IAM API Key      | Required with `TYPE` of `ibmsecretsmanager` and `AUTH_TYPE` of `iam` |
-| AVP_AWS_ACCESS_KEY_ID    | AWS Access Key ID      | Required with `TYPE` of `awssecretsmanager` |
-| AVP_AWS_SECRET_ACCESS_KEY | AWS Secret Access Key      | Required with `TYPE` of `awssecretsmanager` |
-| AVP_AWS_REGION    | AWS Secrets Manager Region      | Only valid with `TYPE` `awssecretsmanager` |
+| AWS_ACCESS_KEY_ID    | AWS Access Key ID      | Required with `TYPE` of `awssecretsmanager` |
+| AWS_SECRET_ACCESS_KEY | AWS Secret Access Key      | Required with `TYPE` of `awssecretsmanager` |
+| AWS_REGION    | AWS Secrets Manager Region      | Only valid with `TYPE` `awssecretsmanager` |
 
 ### Full List of Supported Annotation
 We support two different annotations that can be used inside a kubernetes resource. These annotations will override any corresponding configuration set via Environment Variable or Configuration File.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,9 +68,9 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			map[string]interface{}{
-				"AVP_TYPE":                  "awssecretsmanager",
-				"AVP_AWS_ACCESS_KEY_ID":     "id",
-				"AVP_AWS_SECRET_ACCESS_KEY": "key",
+				"AVP_TYPE":              "awssecretsmanager",
+				"AWS_ACCESS_KEY_ID":     "id",
+				"AWS_SECRET_ACCESS_KEY": "key",
 			},
 			"*backends.AWSSecretsManager",
 		},
@@ -164,8 +164,8 @@ func TestNewConfigMissingParameter(t *testing.T) {
 		},
 		{
 			map[string]interface{}{
-				"AVP_TYPE":              "awssecretsmanager",
-				"AVP_AWS_ACCESS_KEY_ID": "id",
+				"AVP_TYPE":          "awssecretsmanager",
+				"AWS_ACCESS_KEY_ID": "id",
 			},
 			"*backends.AWSSecretsManager",
 		},

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -13,9 +13,9 @@ const (
 	EnvAvpIBMAPIKey       = "AVP_IBM_API_KEY"
 	EnvAvpKvVersion       = "AVP_KV_VERSION"
 	EnvAvpPathPrefix      = "AVP_PATH_PREFIX"
-	EnvAWSAccessKey       = "AVP_AWS_ACCESS_KEY_ID"
-	EnvAWSSecretAccessKey = "AVP_AWS_SECRET_ACCESS_KEY"
-	EnvAWSRegion          = "AVP_AWS_REGION"
+	EnvAWSAccessKey       = "AWS_ACCESS_KEY_ID"
+	EnvAWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+	EnvAWSRegion          = "AWS_REGION"
 
 	// Backend and Auth Constants
 	VaultBackend             = "vault"


### PR DESCRIPTION
### Description
For AWS secrets manager, we have to use the aws defined env vars without the `AVP` prefix.

**Fixes:** #133 #131 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
Also added `k8s` as a valid auth type to the supported parameters table
