### PR TITLE
ci: add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cover.out
 # Project workspaces
 .idea
 .vscode
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,4 +24,4 @@ release:
 changelog:
   filters:
     exclude:
-      - "^(ci|style|test)(\\([^)]+\\))?(!)?:"
+      - "^(ci|style|test|tests)(\\([^)]+\\))?(!)?:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,27 @@
+project_name: "argocd-vault-plugin"
+
+builds:
+  - binary: "argocd-vault-plugin"
+    flags: "-trimpath"
+    ldflags: >-
+      -s -w
+      -X "github.com/IBM/argocd-vault-plugin/version.Version={{.Version}}"
+      -X "github.com/IBM/argocd-vault-plugin/version.BuildDate={{.Date}}"
+      -X "github.com/IBM/argocd-vault-plugin/version.CommitSHA={{.Commit}}"
+    env:
+      - "CGO_ENABLED=0"
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    tags:
+      - netgo
+      - static_build
+
+release:
+  prerelease: auto
+
+changelog:
+  filters:
+    exclude:
+      - "^(ci|style|test)(\\([^)]+\\))?(!)?:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
     flags: "-trimpath"
     ldflags: >-
       -s -w
-      -X "github.com/IBM/argocd-vault-plugin/version.Version={{.Version}}"
+      -X "github.com/IBM/argocd-vault-plugin/version.Version={{.Tag}}"
       -X "github.com/IBM/argocd-vault-plugin/version.BuildDate={{.Date}}"
       -X "github.com/IBM/argocd-vault-plugin/version.CommitSHA={{.Commit}}"
     env:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 BINARY=argocd-vault-plugin
-VERSION=1.0.0
-OS_ARCH=darwin_amd64
 
 default: build
 
@@ -12,8 +10,7 @@ build:
 	go build -o ${BINARY} .
 
 release:
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
-	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
+	goreleaser release --skip-publish --rm-dist
 
 install: build
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,7 +13,7 @@ func NewVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print argocd-vault-plugin version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version.Version)
+			fmt.Printf("argocd-vault-plugin v%s (%s) BuildDate: %s\n", version.Version, version.CommitSHA, version.BuildDate)
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,7 +13,7 @@ func NewVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print argocd-vault-plugin version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("argocd-vault-plugin v%s (%s) BuildDate: %s\n", version.Version, version.CommitSHA, version.BuildDate)
+			fmt.Fprintf(cmd.OutOrStdout(), "argocd-vault-plugin %s (%s) BuildDate: %s\n", version.Version, version.CommitSHA, version.BuildDate)
 		},
 	}
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+	"strings"
+
+	"github.com/IBM/argocd-vault-plugin/version"
+)
+
+func TestVersion(t *testing.T) {
+	t.Run("will show version", func(t *testing.T) {
+		args := []string{}
+		cmd := NewVersionCommand()
+
+		version.Version = "v0.0.1"
+		version.BuildDate = "1970-01-01T:00:00:00Z"
+		version.CommitSHA = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+		c := bytes.NewBufferString("")
+		cmd.SetArgs(args)
+		cmd.SetOut(c)
+		cmd.Execute()
+		out, err := ioutil.ReadAll(c) // Read buffer to bytes
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := "argocd-vault-plugin v0.0.1 (AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) BuildDate: 1970-01-01T:00:00:00Z"
+		if !strings.Contains(string(out), expected) {
+			t.Fatalf("expected to contain: %s but got %s", expected, out)
+		}
+	})
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,11 @@ package version
 
 var (
 	// Version is the argocd-vault-plugin version.
-	Version = "v1.0.0"
+	Version string
+
+	// BuildDate is the date argocd-vault-plugin was built
+	BuildDate string
+
+	// CommitSHA is the commit argocd-vault-plugin was built from
+	CommitSHA string
 )


### PR DESCRIPTION
### Description
Add release automation using goreleaser.  

Example release in my fork: https://github.com/teejaded/argocd-vault-plugin/releases/tag/v1.1.0

To trigger a release, create a new tag with the desired version number.

**Fixes:** https://github.com/IBM/argocd-vault-plugin/issues/14

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information

I also updated the `argocd-vault-plugin version` command. Here's an example of the new output:

```bash
./dist/argocd-vault-plugin_darwin_amd64/argocd-vault-plugin version
argocd-vault-plugin v1.1.0 (5c126d26abe6dbb5f13bbeec6fe90ad39dd18554) BuildDate: 2021-06-08T18:52:31Z
```

For the release automation to work, please add a [secret GH_PAT](https://github.com/IBM/argocd-vault-plugin/settings/secrets/actions) with the value of a GitHub Personal Access Token that has repo scope.

See goreleaser doc for more information if needed.  
https://goreleaser.com/quick-start/
