### PR TITLE
feat: Skip <string>'s with absence of path annotation

### DIFF
--- a/fixtures/output/small-custom-resource-fake-placeholders.yaml
+++ b/fixtures/output/small-custom-resource-fake-placeholders.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  A_SHELL_SCRIPT: bx login --apikey 123
+  description: 'supported options: <beep>, <boop>'
+kind: SomeCustomResource
+metadata:
+  name: some-resource
+  namespace: default

--- a/pkg/helpers/test_helpers.go
+++ b/pkg/helpers/test_helpers.go
@@ -225,3 +225,19 @@ func CreateTestAppRoleVault(t *testing.T) (*vault.TestCluster, string, string) {
 
 	return cluster, roleID, secretID
 }
+
+type MockVault struct {
+	GetSecretsCalled bool
+	Data             map[string]interface{}
+}
+
+func (v *MockVault) Login() error {
+	return nil
+}
+func (v *MockVault) LoadData(data map[string]interface{}) {
+	v.Data = data
+}
+func (v *MockVault) GetSecrets(path string, annotations map[string]string) (map[string]interface{}, error) {
+	v.GetSecretsCalled = true
+	return v.Data, nil
+}

--- a/pkg/kube/template_test.go
+++ b/pkg/kube/template_test.go
@@ -15,13 +15,13 @@ func TestToYAML_Missing_Placeholders(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Secret",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
 				"metadata": map[string]interface{}{
-					"annotations": map[string]interface{}{
-						types.AVPPathAnnotation: "path",
-					},
 					"namespace": "default",
 					"name":      "some-resource",
 				},
@@ -45,6 +45,45 @@ func TestToYAML_Missing_Placeholders(t *testing.T) {
 	}
 }
 
+func TestToYAML_Missing_PlaceholdersSpecificPath(t *testing.T) {
+	mv := helpers.MockVault{}
+	mv.LoadData(map[string]interface{}{
+		"different-placeholder": "string",
+	})
+
+	d := Template{
+		Resource{
+			Kind:        "Secret",
+			Annotations: map[string]string{},
+			TemplateData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"namespace": "default",
+					"name":      "some-resource",
+				},
+				"stringData": map[string]interface{}{
+					"MY_SECRET_STRING": "<path:somewhere#string>",
+				},
+			},
+			Backend: &mv,
+			Data: map[string]interface{}{
+				"string": "this-wont-be-used",
+			},
+		},
+	}
+
+	expectedErr := "Replace: could not replace all placeholders in Template:\nreplaceString: missing Vault value for placeholder path:somewhere#string in string MY_SECRET_STRING: <path:somewhere#string>"
+
+	err := d.Replace()
+	if err == nil {
+		t.Fatalf("expected error %s but got success", expectedErr)
+	}
+
+	if expectedErr != err.Error() {
+		t.Fatalf("expected error \n%s but got error \n%s", expectedErr, err.Error())
+	}
+}
 func TestNewTemplate(t *testing.T) {
 	t.Run("will GetSecrets for placeholder'd YAML", func(t *testing.T) {
 		mv := helpers.MockVault{}
@@ -116,6 +155,9 @@ func TestToYAML_Deployment(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Deployment",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
@@ -169,6 +211,9 @@ func TestToYAML_Service(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Service",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"kind":       "Service",
 				"apiVersion": "v1",
@@ -222,6 +267,9 @@ func TestToYAML_Secret_PlaceholderedData(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Secret",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
@@ -371,6 +419,9 @@ func TestToYAML_Secret_HardcodedData(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Secret",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
@@ -413,6 +464,9 @@ func TestToYAML_Secret_MixedData(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Secret",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
@@ -462,6 +516,9 @@ func TestToYAML_Secret_PlaceholderedStringData(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Secret",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
@@ -510,6 +567,9 @@ func TestToYAML_ConfigMap(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "ConfigMap",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -558,6 +618,9 @@ func TestToYAML_Ingress(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Ingress",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "networking.k8s.io/v1",
 				"kind":       "Ingress",
@@ -612,6 +675,9 @@ func TestToYAML_CronJob(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "CronJob",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "batch/v1beta1",
 				"kind":       "CronJob",
@@ -671,6 +737,9 @@ func TestToYAML_Job(t *testing.T) {
 	d := Template{
 		Resource{
 			Kind: "Job",
+			Annotations: map[string]string{
+				(types.AVPPathAnnotation): "",
+			},
 			TemplateData: map[string]interface{}{
 				"apiVersion": "batch/v1",
 				"kind":       "Job",


### PR DESCRIPTION
### Description

Currently AVP works by reading the path from either the path annotation (`avp.kubernetes.io/path`) or from the specific path set in each placeholder (`<path:somewhere#some-key>`). 

In YAML files where there is no path annotation set, AVP can only work if all placeholders are in the specific path syntax. Therefore, we can make AVP "smarter" by having it ignore generic placeholders of the form `<placeholder>` if the path annotation is missing, since they can't be replaced anyway. This prevents users from having to add ignore annotations to YAMLs that will never contain intentional placeholders, like CRDs. Credits to @llavaud for the idea. 

**Fixes:** #130 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
