### PR TITLE
fix: implicitly base64 encode base64 secret values

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ fieldRef:
   some-credential: <path:somewhere/in/my/vault#credential>
 ```
 
+In addition to the default behavior, the plugin will attempt to decode base64 encoded strings in Secrets to look for placeholders.  If a placeholder is found, it is replaced and the resulting string is re-base64 encoded.  In most cases it is not necessary to use the `base64encode` modifier in this scenario. In the following example the plugin will decode the `POSTGRES_URL` value, find the template `postgres://<username>:<password>@<host>:<port>/<database>?sslmode=require`, and base64 encode it after replacement.
+
+```yaml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: example-secret
+  annotations:
+    avp.kubernetes.io/path: "path/to/secret"
+type: Opaque
+data:
+  POSTGRES_URL: cG9zdGdyZXM6Ly88dXNlcm5hbWU+OjxwYXNzd29yZD5APGhvc3Q+Ojxwb3J0Pi88ZGF0YWJhc2U+P3NzbG1vZGU9cmVxdWlyZQ==
+```
+
 Finally, the plugin will ignore any given YAML file outright with the `avp.kubernetes.io/ignore` annotation set to `"true"`:
 
 ```yaml

--- a/fixtures/input/nonempty/secret_path_base64.yaml
+++ b/fixtures/input/nonempty/secret_path_base64.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  SECRET_VAR: PHBhdGg6c2VjcmV0L3Rlc3Rpbmcjc2VjcmV0LXZhci12YWx1ZT4=
+  SECRET_VAR: PHBhdGg6c2VjcmV0L3Rlc3Rpbmcjc2VjcmV0LXZhci1jbGVhcj4=

--- a/fixtures/input/nonempty/secret_path_base64_substring.yaml
+++ b/fixtures/input/nonempty/secret_path_base64_substring.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+  name: example-secret-base64-substring
+  namespace: default
+type: Opaque
+data:
+  secret.yaml: cGFzc3dvcmQxOiA8cGF0aDpzZWNyZXQvdGVzdGluZyNzZWNyZXQtdmFyLWNsZWFyPgpwYXNzd29yZDI6IDxwYXRoOnNlY3JldC90ZXN0aW5nI3NlY3JldC12YXItY2xlYXI+

--- a/fixtures/output/all.yaml
+++ b/fixtures/output/all.yaml
@@ -130,3 +130,14 @@ metadata:
   namespace: default
 type: Opaque
 ---
+apiVersion: v1
+data:
+  secret.yaml: cGFzc3dvcmQxOiB0ZXN0LXBhc3N3b3JkCnBhc3N3b3JkMjogdGVzdC1wYXNzd29yZA==
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+  name: example-secret-base64-substring
+  namespace: default
+type: Opaque
+---

--- a/pkg/helpers/test_helpers.go
+++ b/pkg/helpers/test_helpers.go
@@ -162,6 +162,7 @@ func CreateTestAppRoleVault(t *testing.T) (*vault.TestCluster, string, string) {
 		"tag":              "1.0",
 		"secret-var-value": "dGVzdC1wYXNzd29yZA==",
 		"secret-num":       "MQ==",
+		"secret-var-clear": "test-password",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -151,7 +151,8 @@ func configReplacement(key, value string, resource Resource) (interface{}, []err
 func secretReplacement(key, value string, resource Resource) (interface{}, []error) {
 	decoded, err := base64.StdEncoding.DecodeString(value)
 	if err == nil && genericPlaceholder.Match(decoded) {
-		return genericReplacement(key, string(decoded), resource)
+		res, err := genericReplacement(key, string(decoded), resource)
+		return base64.StdEncoding.EncodeToString([]byte(stringify(res))), err
 	}
 
 	return genericReplacement(key, value, resource)
@@ -170,6 +171,10 @@ func stringify(input interface{}) string {
 	case json.Number:
 		{
 			return string(input.(json.Number))
+		}
+	case []byte:
+		{
+			return string(input.([]byte))
 		}
 	default:
 		{

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -382,13 +382,47 @@ func TestSecretReplacement_Base64(t *testing.T) {
 
 	expected := Resource{
 		TemplateData: map[string]interface{}{
-			"namespace": []uint8("default"),
+			"namespace": "ZGVmYXVsdA==",
 			"image":     "foo.io/app:latest",
 		},
 		Data: map[string]interface{}{
 			"namespace": "default",
 			"name":      "app",
 			"tag":       "latest",
+		},
+		replacementErrors: []error{},
+	}
+
+	assertSuccessfulReplacement(&dummyResource, &expected, t)
+}
+
+func TestSecretReplacement_Base64Substrings(t *testing.T) {
+	dummyResource := Resource{
+		TemplateData: map[string]interface{}{
+			"data": map[string]interface{}{
+				"credentials": `W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPTxhY2Nlc3Nfa2V5X2lkPgphd3Nfc2VjcmV0X2FjY2Vzc19rZXk9PHNlY3JldF9hY2Nlc3Nfa2V5X2lkPgo=`,
+			},
+		},
+		Data: map[string]interface{}{
+			"access_key_id":        "testkey",
+			"secret_access_key_id": "testsecret",
+		},
+		Annotations: map[string]string{
+			(types.AVPPathAnnotation): "",
+		},
+	}
+
+	replaceInner(&dummyResource, &dummyResource.TemplateData, secretReplacement)
+
+	expected := Resource{
+		TemplateData: map[string]interface{}{
+			"data": map[string]interface{}{
+				"credentials": `W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPXRlc3RrZXkKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5PXRlc3RzZWNyZXQK`,
+			},
+		},
+		Data: map[string]interface{}{
+			"access_key_id":        "testkey",
+			"secret_access_key_id": "testsecret",
 		},
 		replacementErrors: []error{},
 	}
@@ -416,6 +450,10 @@ func TestStringify(t *testing.T) {
 		{
 			json.Number("123"),
 			"123",
+		},
+		{
+			[]byte("bytes"),
+			"bytes",
 		},
 	}
 


### PR DESCRIPTION
### Description
If a secret is successfully decoded from base64, assume it needs to be re-encoded.  This allows for secret values with multiple placeholders or concatenation with other strings. 

**Fixes:** https://github.com/IBM/argocd-vault-plugin/issues/124

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information

