### PR TITLE
fix: env variables check blocks many AWS authentication methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,11 +424,12 @@ AVP_IBM_API_KEY: Your IBM Cloud API Key
 ### AWS Secrets Manager
 
 ##### AWS Authentication
-These are the required parameters parameters for AWS:
+Refer to the [AWS go SDK README](https://github.com/aws/aws-sdk-go#configuring-credentials) for supplying AWS credentials.
+Supported credentials and the order in which they are loaded are described [here](https://github.com/aws/aws-sdk-go/blob/v1.38.62/aws/session/doc.go#L22).
+
+These are the parameters for AWS:
 ```
 AVP_TYPE: awssecretsmanager
-AWS_ACCESS_KEY_ID: Your AWS Access Key ID
-AWS_SECRET_ACCESS_KEY: Your AWS Secret Access Key
 AWS_REGION: Your AWS Region (Optional: defaults to us-east-2)
 ```
 
@@ -487,8 +488,6 @@ We support all Vault Environment Variables listed [here](https://www.vaultprojec
 | AVP_K8S_ROLE       | Kuberentes Auth Role      | Required with `AUTH_TYPE` of `k8s` |
 | AVP_K8S_TOKEN_PATH | Path to JWT for Kubernetes Auth  | Optional for `AUTH_TYPE` of `k8s` defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token` |
 | AVP_IBM_API_KEY    | IBM Cloud IAM API Key      | Required with `TYPE` of `ibmsecretsmanager` and `AUTH_TYPE` of `iam` |
-| AWS_ACCESS_KEY_ID    | AWS Access Key ID      | Required with `TYPE` of `awssecretsmanager` |
-| AWS_SECRET_ACCESS_KEY | AWS Secret Access Key      | Required with `TYPE` of `awssecretsmanager` |
 | AWS_REGION    | AWS Secrets Manager Region      | Only valid with `TYPE` `awssecretsmanager` |
 
 ### Full List of Supported Annotation

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,13 +109,6 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 		}
 	case types.AWSSecretsManagerbackend:
 		{
-			if !v.IsSet(types.EnvAWSAccessKey) || !v.IsSet(types.EnvAWSSecretAccessKey) {
-				return nil, fmt.Errorf("Must provide %s and %s for backend type %s",
-					types.EnvAWSAccessKey,
-					types.EnvAWSSecretAccessKey,
-					types.AWSSecretsManagerbackend,
-				)
-			}
 			s := session.Must(session.NewSession(&aws.Config{
 				Region: aws.String(v.GetString(types.EnvAWSRegion)),
 			}))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,7 +153,7 @@ func readConfigOrSecret(secretName, configPath string, v *viper.Viper) error {
 	}
 
 	for k, viperValue := range v.AllSettings() {
-		if strings.HasPrefix(k, "vault") {
+		if strings.HasPrefix(k, "vault") || strings.HasPrefix(k, "aws") {
 			var value string
 			switch viperValue.(type) {
 			case bool:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,9 +109,13 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 		}
 	case types.AWSSecretsManagerbackend:
 		{
-			s := session.Must(session.NewSession(&aws.Config{
+			s, err := session.NewSession(&aws.Config{
 				Region: aws.String(v.GetString(types.EnvAWSRegion)),
-			}))
+			})
+			if err != nil {
+				return nil, err
+			}
+
 			client := secretsmanager.New(s)
 			backend = backends.NewAWSSecretsManagerBackend(client)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -162,13 +162,6 @@ func TestNewConfigMissingParameter(t *testing.T) {
 			},
 			"*backends.IBMSecretsManager",
 		},
-		{
-			map[string]interface{}{
-				"AVP_TYPE":          "awssecretsmanager",
-				"AWS_ACCESS_KEY_ID": "id",
-			},
-			"*backends.AWSSecretsManager",
-		},
 	}
 	for _, tc := range testCases {
 		for k, v := range tc.environment {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -74,6 +74,15 @@ func TestNewConfig(t *testing.T) {
 			},
 			"*backends.AWSSecretsManager",
 		},
+		{ // auth via web identity federation is also possible
+			map[string]interface{}{
+				"AVP_TYPE":                    "awssecretsmanager",
+				"AWS_REGION":                  "us-west-1",
+				"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+				"AWS_ROLE_ARN":                "arn:aws:iam::111111111:role/argocd-repo-server-secretsmanager-my-cluster",
+			},
+			"*backends.AWSSecretsManager",
+		},
 	}
 	for _, tc := range testCases {
 		for k, v := range tc.environment {
@@ -161,6 +170,14 @@ func TestNewConfigMissingParameter(t *testing.T) {
 				"AVP_IAM_API_KEY": "token",
 			},
 			"*backends.IBMSecretsManager",
+		},
+		{ //  WebIdentityEmptyRoleARNErr will occur if 'AWS_WEB_IDENTITY_TOKEN_FILE' was set but 'AWS_ROLE_ARN' was not set.
+			map[string]interface{}{
+				"AVP_TYPE":                    "awssecretsmanager",
+				"AWS_REGION":                  "us-west-1",
+				"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+			},
+			"*backends.AWSSecretsManager",
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -2,20 +2,18 @@ package types
 
 const (
 	// Environment Variable Constants
-	EnvAvpType            = "AVP_TYPE"
-	EnvAvpRoleID          = "AVP_ROLE_ID"
-	EnvAvpSecretID        = "AVP_SECRET_ID"
-	EnvAvpAuthType        = "AVP_AUTH_TYPE"
-	EnvAvpGithubToken     = "AVP_GITHUB_TOKEN"
-	EnvAvpK8sRole         = "AVP_K8S_ROLE"
-	EnvAvpK8sMountPath    = "AVP_K8S_MOUNT_PATH"
-	EnvAvpK8sTokenPath    = "AVP_K8S_TOKEN_PATH"
-	EnvAvpIBMAPIKey       = "AVP_IBM_API_KEY"
-	EnvAvpKvVersion       = "AVP_KV_VERSION"
-	EnvAvpPathPrefix      = "AVP_PATH_PREFIX"
-	EnvAWSAccessKey       = "AWS_ACCESS_KEY_ID"
-	EnvAWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
-	EnvAWSRegion          = "AWS_REGION"
+	EnvAvpType         = "AVP_TYPE"
+	EnvAvpRoleID       = "AVP_ROLE_ID"
+	EnvAvpSecretID     = "AVP_SECRET_ID"
+	EnvAvpAuthType     = "AVP_AUTH_TYPE"
+	EnvAvpGithubToken  = "AVP_GITHUB_TOKEN"
+	EnvAvpK8sRole      = "AVP_K8S_ROLE"
+	EnvAvpK8sMountPath = "AVP_K8S_MOUNT_PATH"
+	EnvAvpK8sTokenPath = "AVP_K8S_TOKEN_PATH"
+	EnvAvpIBMAPIKey    = "AVP_IBM_API_KEY"
+	EnvAvpKvVersion    = "AVP_KV_VERSION"
+	EnvAvpPathPrefix   = "AVP_PATH_PREFIX"
+	EnvAWSRegion       = "AWS_REGION"
 
 	// Backend and Auth Constants
 	VaultBackend             = "vault"


### PR DESCRIPTION
### Description

Enforcing the specification of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env variables blocks other authentication methods supported by the AWS go SDK from being used by argocd-vault-plugin. Even within env vars authentication, there exist other options than just `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`: e.g. using an assumed role on ec2/EKS. This PR removes the unnecessary check for the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars. It does remain recommended to set the proper AWS region via an environment variables however. 

**Fixes:** https://github.com/IBM/argocd-vault-plugin/issues/148

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information

Note, this PR was tested successfully with an IAM role for service accounts as the auth method on an AWS EKS cluster. In this test the following env variables were set by the EKS Pod Identity Webhook:
```
AWS_ROLE_ARN=arn:aws:iam::xxx:role/argocd-repo-server-secretsmanager-my-cluster
AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
AWS_DEFAULT_REGION=eu-west-1
AWS_REGION=eu-west-1
```

Note, when no credentials are found the user is shown the following error after this PR is applied:
```
AVP_TYPE=awssecretsmanager ./bin/argocd-vault-plugin_1.2.0dev_linux_amd64 generate /tmp/secret.yaml
Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
Usage:
  argocd-vault-plugin generate <path> [flags]

Flags:
  -c, --config-path string   path to a file containing Vault configuration (YAML, JSON, envfile) to use
  -h, --help                 help for generate
  -s, --secret-name string   name of a Kubernetes Secret containing Vault configuration data in the argocd namespace of your ArgoCD host (Only available when used in ArgoCD)

NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```
