### PR TITLE
fix: issue warning when default aws region is used

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -36,7 +37,6 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 
 	// Set Defaults
 	v.SetDefault(types.EnvAvpKvVersion, "2")
-	v.SetDefault("AWS_REGION", "us-east-2")
 
 	// Read in config file or kubernetes secret and set as env vars
 	err := readConfigOrSecret(co.SecretName, co.ConfigPath, v)
@@ -109,6 +109,11 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 		}
 	case types.AWSSecretsManagerbackend:
 		{
+			if !v.IsSet(types.EnvAWSRegion) { // issue warning when using default region
+				log.Printf("Warning: %s env var not set, using AWS region %s.\n", types.EnvAWSRegion, types.AwsDefaultRegion)
+				v.Set(types.EnvAWSRegion, types.AwsDefaultRegion)
+			}
+
 			s, err := session.NewSession(&aws.Config{
 				Region: aws.String(v.GetString(types.EnvAWSRegion)),
 			})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -67,9 +67,18 @@ func TestNewConfig(t *testing.T) {
 			},
 			"*backends.IBMSecretsManager",
 		},
-		{
+		{ // this test issues a warning for missing AWS_REGION env var
 			map[string]interface{}{
 				"AVP_TYPE":              "awssecretsmanager",
+				"AWS_ACCESS_KEY_ID":     "id",
+				"AWS_SECRET_ACCESS_KEY": "key",
+			},
+			"*backends.AWSSecretsManager",
+		},
+		{ // no warning is issued
+			map[string]interface{}{
+				"AVP_TYPE":              "awssecretsmanager",
+				"AWS_REGION":            "us-west-1",
 				"AWS_ACCESS_KEY_ID":     "id",
 				"AWS_SECRET_ACCESS_KEY": "key",
 			},

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -23,6 +23,7 @@ const (
 	ApproleAuth              = "approle"
 	GithubAuth               = "github"
 	IAMAuth                  = "iam"
+	AwsDefaultRegion         = "us-east-2"
 
 	AVPPathAnnotation        = "avp.kubernetes.io/path"
 	AVPIgnoreAnnotation      = "avp.kubernetes.io/ignore"


### PR DESCRIPTION
### Description
Issue a warning to inform the user that (s)he forget to set `AWS_REGION` and that the default region will be used.
Note this PR is blocked by PR #151.

**Fixes:** https://github.com/IBM/argocd-vault-plugin/issues/154

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
