### PR TITLE
fix: dont replace entire string if base64 modifier included

### DIFF
--- a/fixtures/input/nonempty/secret_embedded_base64.yaml
+++ b/fixtures/input/nonempty/secret_embedded_base64.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+    avp.kubernetes.io/path: secret/testing
+  name: embedded-secret-base64
+  namespace: default
+type: Opaque
+data:
+  secret.yaml: c29tZQ==<secret-var-clear | base64encode>dmFsdWU=

--- a/fixtures/output/all.yaml
+++ b/fixtures/output/all.yaml
@@ -110,6 +110,18 @@ type: Opaque
 ---
 apiVersion: v1
 data:
+  secret.yaml: c29tZQ==dGVzdC1wYXNzd29yZA==dmFsdWU=
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+    avp.kubernetes.io/path: secret/testing
+  name: embedded-secret-base64
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
   SECRET_VAR: dGVzdC1wYXNzd29yZA==,dGVzdC1wYXNzd29yZDI=
 kind: Secret
 metadata:

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -69,7 +69,7 @@ func (t *Template) Replace() error {
 	replaceInner(&t.Resource, &t.TemplateData, replacerFunc)
 	if len(t.replacementErrors) != 0 {
 		errMessages := make([]string, len(t.replacementErrors))
-		for idx, err := range(t.replacementErrors) {
+		for idx, err := range t.replacementErrors {
 			errMessages[idx] = err.Error()
 		}
 		return fmt.Errorf("Replace: could not replace all placeholders in Template:\n%s", strings.Join(errMessages, "\n"))

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -111,8 +111,7 @@ func genericReplacement(key, value string, resource Resource) (_ interface{}, er
 			case string:
 				{
 					if base64modifier {
-						nonStringReplacement = []byte(stringify(secretValue))
-						return match
+						return []byte(base64.StdEncoding.EncodeToString([]byte(secretValue.(string))))
 					}
 					return []byte(secretValue.(string))
 				}
@@ -135,6 +134,7 @@ func genericReplacement(key, value string, resource Resource) (_ interface{}, er
 	if nonStringReplacement != nil {
 		return nonStringReplacement, err
 	}
+
 	return string(res), err
 }
 

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -202,7 +203,7 @@ func TestGenericReplacement_Base64(t *testing.T) {
 
 	expected := Resource{
 		TemplateData: map[string]interface{}{
-			"namespace": []uint8("default"),
+			"namespace": base64.StdEncoding.EncodeToString([]byte("default")),
 			"image":     "foo.io/app:latest",
 		},
 		Data: map[string]interface{}{
@@ -348,7 +349,7 @@ func TestSecretReplacement(t *testing.T) {
 
 	expected := Resource{
 		TemplateData: map[string]interface{}{
-			"namespace": []uint8("default"),
+			"namespace": base64.StdEncoding.EncodeToString([]byte("default")),
 			"image":     "foo.io/app:latest",
 		},
 		Data: map[string]interface{}{
@@ -382,7 +383,7 @@ func TestSecretReplacement_Base64(t *testing.T) {
 
 	expected := Resource{
 		TemplateData: map[string]interface{}{
-			"namespace": "ZGVmYXVsdA==",
+			"namespace": "WkdWbVlYVnNkQT09",
 			"image":     "foo.io/app:latest",
 		},
 		Data: map[string]interface{}{


### PR DESCRIPTION
### Description
Fixes an issue where if the bas64 modifier is included in a longer string it was replacing the entire string

**Fixes:** #162 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)