### PR TITLE
docs: update argocd-cm plugin setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ configManagementPlugins: |
       args: ["helm dependency build"]
     generate:
       command: ["sh", "-c"]
-      args: ["helm template . > all.yaml && argocd-vault-plugin generate all.yaml"]
+      args: ["helm template $ARGOCD_APP_NAME . > all.yaml && argocd-vault-plugin generate all.yaml"]
 ```
 
 If you want to use Helm along with argocd-vault-plugin and use additional helm args :
@@ -278,7 +278,7 @@ configManagementPlugins: |
       args: ["helm dependency build"]
     generate:
       command: ["sh", "-c"]
-      args: ["helm template ${helm_args} . > all.yaml && argocd-vault-plugin generate all.yaml"]
+      args: ["helm template $ARGOCD_APP_NAME ${helm_args} . > all.yaml && argocd-vault-plugin generate all.yaml"]
 ```
 Helm args must be defined in the application manifest:
 ```yaml


### PR DESCRIPTION
### Description
The application name of the Argo CD maps to Helm Chart's Relase Name.

When ArgoCD sync, environment varivable  "ARGOCD_APP_NAME" set ArgoCD  application name

[Argocd Docs](https://argoproj.github.io/argo-cd/user-guide/helm/#helm-release-name)

if ArgoCD application name is "certificate-exporter"

before(use `helm template . > all.yaml`)
RELEASE-NAME-x509-certificate-exporter-headless

after(use `helm template $ARGOCD_APP_NAME . > all.yaml`)
certificate-exporter-x509-certificate-exporter-headless

**Fixes:** <! -- link to issue -->

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
