### PR TITLE
feat: return plain secret value if secret ist not a valid json

### DIFF
--- a/pkg/backends/awssecretsmanager.go
+++ b/pkg/backends/awssecretsmanager.go
@@ -40,9 +40,15 @@ func (a *AWSSecretsManager) GetSecrets(path string, _ map[string]string) (map[st
 	var dat map[string]interface{}
 
 	if result.SecretString != nil {
-		err := json.Unmarshal([]byte(*result.SecretString), &dat)
-		if err != nil {
-			return nil, err
+		if json.Valid([]byte(*result.SecretString)) {
+			err := json.Unmarshal([]byte(*result.SecretString), &dat)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			dat = map[string]interface{}{
+				"plainValue": *result.SecretString,
+			}
 		}
 	} else {
 		return nil, fmt.Errorf("Could not find secret %s", path)


### PR DESCRIPTION
### Description
It is possible to save plaintext secrets in aws secretsmanager. (Example use case : License). Since they are not a JSON object, the need to be treated differently. 

<path:/path/to/my/secret#plainValue>

In case the secret is not a JSON it will return the plain secret value. The key needs to be "#plainValue" 


### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information

