### PR TITLE
feat: Support JSON manifests

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -38,9 +38,9 @@ func NewGenerateCommand() *cobra.Command {
 					return err
 				}
 			} else {
-				files, err := listYamlFiles(path)
+				files, err := listFiles(path)
 				if len(files) < 1 {
-					return fmt.Errorf("no YAML files were found in %s", path)
+					return fmt.Errorf("no YAML or JSON files were found in %s", path)
 				}
 				if err != nil {
 					return err
@@ -50,7 +50,7 @@ func NewGenerateCommand() *cobra.Command {
 				manifests, errs = readFilesAsManifests(files)
 				if len(errs) != 0 {
 					// TODO: handle multiple errors nicely
-					return fmt.Errorf("could not read YAML files: %s", errs)
+					return fmt.Errorf("could not read YAML/JSON files: %s", errs)
 				}
 			}
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -57,7 +57,7 @@ func TestMain(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := "no YAML files were found in ./fixtures/input/empty/"
+		expected := "no YAML or JSON files were found in ./fixtures/input/empty/"
 		if !strings.Contains(string(out), expected) {
 			t.Fatalf("expected to contain: %s but got %s", expected, out)
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -12,11 +12,11 @@ import (
 	k8yaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func listYamlFiles(root string) ([]string, error) {
+func listFiles(root string) ([]string, error) {
 	var files []string
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" {
+		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" || filepath.Ext(path) == ".json" {
 			files = append(files, path)
 		}
 		return nil
@@ -32,11 +32,11 @@ func readFilesAsManifests(paths []string) (result []unstructured.Unstructured, e
 	for _, path := range paths {
 		rawdata, err := ioutil.ReadFile(path)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("could not read YAML: %s from disk: %s", path, err))
+			errs = append(errs, fmt.Errorf("could not read file: %s from disk: %s", path, err))
 		}
 		manifest, err := readManifestData(bytes.NewReader(rawdata))
 		if err != nil {
-			errs = append(errs, fmt.Errorf("could not read YAML: %s from disk: %s", path, err))
+			errs = append(errs, fmt.Errorf("could not read file: %s from disk: %s", path, err))
 		}
 		result = append(result, manifest...)
 	}
@@ -45,7 +45,7 @@ func readFilesAsManifests(paths []string) (result []unstructured.Unstructured, e
 }
 
 func readManifestData(yamlData io.Reader) ([]unstructured.Unstructured, error) {
-	decoder := k8yaml.NewYAMLToJSONDecoder(yamlData)
+	decoder := k8yaml.NewYAMLOrJSONDecoder(yamlData, 1)
 
 	var manifests []unstructured.Unstructured
 	for {

--- a/docs/howitworks.md
+++ b/docs/howitworks.md
@@ -1,9 +1,10 @@
-The argocd-vault-plugin works by taking a directory of yaml files that have been templated out using the pattern of `<placeholder>` where you would want a value from Vault to go. The inside of the `<>` would be the actual key in Vault.
+The argocd-vault-plugin works by taking a directory of YAML or JSON files that have been templated out using the pattern of `<placeholder>` where you would want a value from Vault to go. The inside of the `<>` would be the actual key in Vault.
 
 An annotation can be used to specify exactly where the plugin should look for the vault values. The annotation needs to be in the format `avp.kubernetes.io/path: "path/to/secret"`.
 
-For example, if you have a secret with the key `password-vault-key` that you would want to pull from vault, you might have a yaml that looks something like the below code. In this yaml, the plugin will pull the value of `path/to/secret/password-vault-key` and inject it into the secret yaml.
+For example, if you have a secret with the key `password-vault-key` that you would want to pull from vault, you might have a yaml that looks something like the below code. In this yaml, the plugin will pull the value of `path/to/secret/password-vault-key` and inject it into the Secret.
 
+As YAML:
 ```yaml
 kind: Secret
 apiVersion: v1
@@ -16,7 +17,25 @@ data:
   password: <password-vault-key>
 ```
 
-And then once the plugin is done doing the substitutions, it outputs the yaml to standard out to then be applied by Argo CD. The resulting yaml would look like:
+As JSON:
+```json
+{
+  "kind": "Secret",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "example-secret",
+    "annotations": {
+      "avp.kubernetes.io/path": "path/to/secret"
+    }
+  },
+  "type": "Opaque",
+  "data": {
+    "password": "<password-vault-key>"
+  }
+}
+```
+
+And then once the plugin is done doing the substitutions, it outputs the manifest as YAML to standard out to then be applied by Argo CD. The resulting YAML would look like:
 ```yaml
 kind: Secret
 apiVersion: v1
@@ -41,7 +60,7 @@ data:
   password: <path:path/to/secret#password-vault-key>
 ```
 
-The plugin tries to be helpful and will ignore strings in the format `<string>` if the `avp.kubernetes.io/path` annotation is missing, and only consider strings in the format `<path:/path/to/secret#key>` as placeholders. This can be very useful when using AVP with YAML that uses `<string>`'s for other purposes, for example in CRD's with usage information:
+The plugin tries to be helpful and will ignore strings in the format `<string>` if the `avp.kubernetes.io/path` annotation is missing, and only consider strings in the format `<path:/path/to/secret#key>` as placeholders. This can be very useful when using AVP with YAML/JSON that uses `<string>`'s for other purposes, for example in CRD's with usage information:
 
 ```yaml
 kind: CustomResourceDefinition
@@ -80,7 +99,7 @@ data:
   POSTGRES_URL: cG9zdGdyZXM6Ly88dXNlcm5hbWU+OjxwYXNzd29yZD5APGhvc3Q+Ojxwb3J0Pi88ZGF0YWJhc2U+P3NzbG1vZGU9cmVxdWlyZQ==
 ```
 
-Finally, the plugin will ignore any given YAML file outright with the `avp.kubernetes.io/ignore` annotation set to `"true"`:
+Finally, the plugin will ignore any given YAML/JSON file outright with the `avp.kubernetes.io/ignore` annotation set to `"true"`:
 
 ```yaml
 kind: CustomResourceDefinition

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -126,13 +126,24 @@ Helm args must be defined in the application manifest:
           value: -f values-dev.yaml -f values-dev-tag.yaml
 ```
 
-Or if you are using Kustomize:
+If you are using Kustomize add:
 ```yaml
 configManagementPlugins: |
   - name: argocd-vault-plugin-kustomize
     generate:
       command: ["sh", "-c"]
       args: ["kustomize build . > all.yaml && argocd-vault-plugin generate all.yaml"]
+```
+
+to the `argocd-cm` configMap.
+
+Or if you are using Jsonnet add:
+```yaml
+configManagementPlugins: |
+  - name: argocd-vault-plugin-jsonnet
+    generate:
+      command: ["sh", "-c"]
+      args: ["jsonnet . | argocd-vault-plugin generate -"]
 ```
 
 to the `argocd-cm` configMap.

--- a/fixtures/input/nonempty/secret.json
+++ b/fixtures/input/nonempty/secret.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "annotations": {
+      "avp.kubernetes.io/path": "secret/testing",
+      "avp.kubernetes.io/kv-version": "1"
+    },
+    "name": "<name>-json",
+    "namespace": "<namespace>"
+  },
+  "type": "Opaque",
+  "data": {
+    "SECRET_VAR": "<secret-var-value>",
+    "SECRET_NUM": "<secret-num>"
+  }
+}

--- a/fixtures/output/all.yaml
+++ b/fixtures/output/all.yaml
@@ -104,6 +104,19 @@ metadata:
   annotations:
     avp.kubernetes.io/kv-version: "1"
     avp.kubernetes.io/path: secret/testing
+  name: test-name-json
+  namespace: test-namespace
+type: Opaque
+---
+apiVersion: v1
+data:
+  SECRET_NUM: MQ==
+  SECRET_VAR: dGVzdC1wYXNzd29yZA==
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+    avp.kubernetes.io/path: secret/testing
   name: test-name
   namespace: test-namespace
 type: Opaque


### PR DESCRIPTION
### Description

Adds support for JSON files as input. Since ArgoCD plugins _must_ generate YAML output (https://argoproj.github.io/argo-cd/user-guide/config-management-plugins/#plugins), the JSON is replaced and then output as YAML. 

**Fixes:** #181 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
