### PR TITLE
ci: Use Docker for CI on Linux

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,20 +1,38 @@
 name: Pipeline
 
 on:
-  push:
-    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main, next]
 
 jobs:
-  CI:
-    name: CI
+  linux:
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download deps
+        run: docker build . -t ci
+
+      # Disable network so that Azure specific behavior doesn't happen
+      - name: Quality
+        run: docker run --network none --env GOPATH="" --rm -v $PWD:/go/work ci make quality
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+
+      - name: Build and test plugin
+        run: docker run --network none --env GOPATH="" --rm -v $PWD:/go/work ci make e2e
+  mac:
+    strategy:
+      fail-fast: false
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -26,9 +44,6 @@ jobs:
 
       - name: Quality checks
         run: make quality
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
 
       - name: Build and test plugin
         run: make e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang@sha256:a92abf53d0ac8dd292b432525c15ce627554546ebc4164d1d4149256998122ce
+
+RUN apk add make
+
+ADD go.mod go.mod
+ADD go.sum go.sum
+
+ENV GOPATH=""
+ENV CGO_ENABLED=0
+RUN go mod download
+
+VOLUME work
+WORKDIR work

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 BINARY=argocd-vault-plugin
-VERSION=1.1.1
-OS_ARCH=darwin_amd64
 
 default: build
 
 quality:
-	go vet github.com/IBM/argocd-vault-plugin/...
+	go vet github.com/IBM/argocd-vault-plugin
 	go test -v -coverprofile cover.out ./...
 
 build:


### PR DESCRIPTION
### Description

Dockerize the CI environment on Linux to avoid this problem: https://github.com/IBM/argocd-vault-plugin/pull/193#issuecomment-911876575. 

This solution works based on this Actions run https://github.com/IBM/argocd-vault-plugin/runs/3508366010?check_suite_focus=true which makes these changes atop PR 193 to prove we avoid the special-case of Azure auth solely via cloud-provider metadata endpoints

Specific CI changes:

- Split the CI matrix since we use Docker on Linux not on Mac
- Add a Dockerfile that downloads the Golang deps at build time
- Run `go vet` only on our code (nor our deps) and run `go test` in a network isolated container to avoid successful Azure auth
- Upload code coverage only once
- Remove some un-used stuff from the Makefile

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
