### PR TITLE
fix(aws): Omit versionId unless specified

### DIFF
--- a/pkg/backends/awssecretsmanager.go
+++ b/pkg/backends/awssecretsmanager.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/IBM/argocd-vault-plugin/pkg/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
@@ -30,12 +29,11 @@ func (a *AWSSecretsManager) Login() error {
 // GetSecrets gets secrets from aws secrets manager and returns the formatted data
 func (a *AWSSecretsManager) GetSecrets(path string, version string, annotations map[string]string) (map[string]interface{}, error) {
 	input := &secretsmanager.GetSecretValueInput{
-		SecretId:  aws.String(path),
-		VersionId: aws.String(types.AWSCurrentSecretVersion),
+		SecretId: aws.String(path),
 	}
 
 	if version != "" {
-		input.VersionId = aws.String(version)
+		input.SetVersionId(version)
 	}
 
 	result, err := a.Client.GetSecretValue(input)

--- a/pkg/backends/awssecretsmanager_test.go
+++ b/pkg/backends/awssecretsmanager_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/backends"
-	"github.com/IBM/argocd-vault-plugin/pkg/types"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 )
@@ -19,7 +18,7 @@ func (m *mockSecretsManagerClient) GetSecretValue(input *secretsmanager.GetSecre
 
 	switch *input.SecretId {
 	case "test":
-		if *input.VersionId == types.AWSCurrentSecretVersion {
+		if input.VersionId == nil {
 			string := "{\"test-secret\":\"current-value\"}"
 			data.SecretString = &string
 		} else {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -28,7 +28,6 @@ const (
 	TokenAuth                = "token"
 	IAMAuth                  = "iam"
 	AwsDefaultRegion         = "us-east-2"
-	AWSCurrentSecretVersion  = "AWSCURRENT"
 	GCPCurrentSecretVersion  = "latest"
 
 	// Supported annotations


### PR DESCRIPTION
### Description

Don't use `AWSCURRENT` as a value for `VersionId` when no version is specified: instead just omit the field entirely

**Fixes:** #199 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
