### PR TITLE
docs: Redirect old docs to stable

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting</title>
+  <noscript>
+    <meta http-equiv="refresh" content="1; url=/argocd-vault-plugin/stable/" />
+  </noscript>
+  <script>
+    const matches = window.location.pathname.match("\/argocd-vault-plugin\/([^\/]*(?:\/)?(?:#.*)?)$");
+
+    // Redirect old documentation links from before versioned-docs to the stable version of that page
+    if (matches !== null) {
+      window.location.replace(`/argocd-vault-plugin/stable/${matches[1]}`);
+    }
+
+    // Actual 404, just go to stable docs
+    else {
+      window.location.replace(`/argocd-vault-plugin/stable/`);
+    }
+  </script>
+</head>
+</html>


### PR DESCRIPTION
### Description

Adds 404 page that will redirect to `/stable/<rest of path>` so that old links like https://ibm.github.io/argocd-vault-plugin/installation/#custom-image will work

Proof it works: <https://jkayani.github.io/argocd-vault-plugin/installation/#custom-image>

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
