### PR TITLE
docs: Hide banner if not browsing main docs

### DIFF
--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -4,6 +4,8 @@
 {% block announce %}
   <div id="version-banner">
   <script>
+
+    // Show banner for people browsing the `main` docs that it is out of date
     if (window.location.pathname.match("^\/argocd-vault-plugin\/main\/.*") !== null) {
       const banner = document.createElement("h4");
       const msg = document.createTextNode("These docs are from the main branch and may reference unreleased features. ");
@@ -17,6 +19,11 @@
 
       const currentDiv = document.getElementById("version-banner");
       currentDiv.appendChild(banner);
+    }
+
+    // Hide the banner entirely otherwise
+    else {
+      document.getElementsByClassName("md-announce")[0].setAttribute("style", "display: none;");
     }
   </script>
   </div>


### PR DESCRIPTION
### Description

Hide banner if not browsing main docs. Need to regenerate all previously generated docs again.

Script to regenerate previous docs:

```sh
git checkout gh-pages
git rm -rf main/ preview/ stable/ v1.*/ index.html versions.json
git commit -m "docs: Cleanup existing docs"
tags=( "v1.2.0" "v1.3.0" "v1.3.1" )
for tag in "${tags[@]}"
do
  git checkout $tag --force
  git cherry-pick a58845efdaaf4202b7238fc4b80c8b637cdc96b6
  git cherry-pick theme-fix
  mike deploy -u $tag stable
done
mike set-default stable
git push --force origin gh-pages:gh-pages
```

Script tested here: https://github.com/jkayani/argocd-vault-plugin/tree/gh-pages

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
