### PR TITLE
perf(ibmsecretsmanager): Get secrets concurrently

### DIFF
--- a/pkg/backends/ibmsecretsmanager.go
+++ b/pkg/backends/ibmsecretsmanager.go
@@ -3,7 +3,9 @@ package backends
 import (
 	"fmt"
 	"regexp"
+	"sync"
 
+	"github.com/IBM/argocd-vault-plugin/pkg/types"
 	"github.com/IBM/go-sdk-core/v5/core"
 	ibmsm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1"
 )
@@ -35,6 +37,49 @@ func (i *IBMSecretsManager) Login() error {
 	return nil
 }
 
+// getSecret sends the result of getting the `secret` from IBM SM in a map over a channel
+// `name` is the name of the secret and is always set
+// `err` is set if there is an error getting the secret
+// `payload` is the secrets `payload` and is set if successful
+// The goroutine only terminates once IBMMaxRetries or fewer attempts are made
+func (i *IBMSecretsManager) getSecret(secret *ibmsm.SecretResource, response chan map[string]interface{}, wg *sync.WaitGroup) {
+	result := make(map[string]interface{})
+	result["name"] = *secret.Name
+
+	// `version` is ignored since IBM SM does not support versioning for `arbitrary` secrets
+	// https://github.com/IBM/argocd-vault-plugin/issues/58#issuecomment-906477921
+	secretRes, httpResponse, err := i.Client.GetSecret(&ibmsm.GetSecretOptions{
+		SecretType: secret.SecretType,
+		ID:         secret.ID,
+	})
+	if err != nil {
+		result["err"] = fmt.Errorf("Could not retrieve secret %s: %s", *secret.ID, err)
+	}
+
+	if secretRes == nil {
+		result["err"] = fmt.Errorf("Could not retrieve secret %s after %d retries, statuscode %d", *secret.ID, types.IBMMaxRetries, httpResponse.GetStatusCode())
+	} else {
+		secretResource := secretRes.Resources[0].(*ibmsm.SecretResource)
+		secretData := secretResource.SecretData.(map[string]interface{})
+		if secretData["payload"] == nil {
+			result["err"] = fmt.Errorf("No `payload` key present for secret with id %s: Is this an `arbitrary` type secret?", *secret.ID)
+		} else {
+			result["payload"] = secretData["payload"]
+		}
+	}
+
+	response <- result
+	wg.Done()
+}
+
+func storeSecret(secrets *map[string]interface{}, result map[string]interface{}) error {
+	if result["err"] != nil {
+		return result["err"].(error)
+	}
+	(*secrets)[result["name"].(string)] = result["payload"]
+	return nil
+}
+
 // GetSecrets returns the data for a secret in IBM Secrets Manager
 // It only works for `arbitrary` secret types
 func (i *IBMSecretsManager) GetSecrets(path string, version string, annotations map[string]string) (map[string]interface{}, error) {
@@ -47,42 +92,68 @@ func (i *IBMSecretsManager) GetSecrets(path string, version string, annotations 
 	}
 
 	// Enumerate the secret names and their ids
+	// The IBM SM API returns a max of MAX_PER_PAGE results, so if we get that many on the first request, there might be more secrets
 	groupid := matches[IBMPath.SubexpIndex("groupid")]
-	result, details, err := i.Client.ListAllSecrets(&ibmsm.ListAllSecretsOptions{
-		Groups: []string{groupid},
-	})
+	var offset int64 = 0
+	var result []ibmsm.SecretResourceIntf
+	for {
+		res, details, err := i.Client.ListAllSecrets(&ibmsm.ListAllSecretsOptions{
+			Groups: []string{groupid},
+			Offset: &offset,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Could not list secrets for secret group %s: %s\n%s", groupid, err, details.String())
+		}
+		if res == nil {
+			return nil, fmt.Errorf("Could not list secrets for secret group %s: %d\n%s", groupid, details.GetStatusCode(), details.String())
+		}
 
-	if err != nil {
-		return nil, fmt.Errorf("Could not list secrets for secret group %s: %s\n%s", groupid, err, details)
+		result = append(result, res.Resources...)
+
+		if len(res.Resources) < types.IBMMaxPerPage {
+			break
+		}
+		offset += int64(types.IBMMaxPerPage)
 	}
 
+	// Using MAX_GOROUTINES at a time, retrieve the secrets of the right type from the group
+	secretResult := make(chan map[string]interface{})
 	secrets := make(map[string]interface{})
-	for _, resource := range result.Resources {
+	var wg sync.WaitGroup
+	MAX_GOROUTINES := 20
+
+	for k, resource := range result {
 		if secret, ok := resource.(*ibmsm.SecretResource); ok {
 			if *secret.SecretType == matches[IBMPath.SubexpIndex("type")] {
-				secrets[*secret.Name] = secret.ID
+
+				// There is space for more goroutines, so spawn immediately and continue
+				if k < MAX_GOROUTINES {
+					go i.getSecret(secret, secretResult, &wg)
+					wg.Add(1)
+					continue
+				}
+
+				// Wait for a goroutine to finish before spawning another
+				err := storeSecret(&secrets, <-secretResult)
+				if err != nil {
+					return nil, err
+				}
+
+				go i.getSecret(secret, secretResult, &wg)
+				wg.Add(1)
 			}
 		}
 	}
 
-	// Get each secrets value from its ID
-	for name, id := range secrets {
+	go func() {
+		wg.Wait()
+		close(secretResult)
+	}()
 
-		// `version` is ignored since IBM SM does not support versioning for `arbitrary` secrets
-		// https://github.com/IBM/argocd-vault-plugin/issues/58#issuecomment-906477921
-		secretRes, _, err := i.Client.GetSecret(&ibmsm.GetSecretOptions{
-			SecretType: &matches[IBMPath.SubexpIndex("type")],
-			ID:         id.(*string),
-		})
+	for secret := range secretResult {
+		err := storeSecret(&secrets, secret)
 		if err != nil {
-			return nil, fmt.Errorf("Could not retrieve secret %s: %s", *(id.(*string)), err)
-		}
-
-		secretResource := secretRes.Resources[0].(*ibmsm.SecretResource)
-		secretData := secretResource.SecretData.(map[string]interface{})
-		secrets[name] = secretData["payload"]
-		if secrets[name] == nil {
-			return nil, fmt.Errorf("No `payload` key present for secret at path %s: Is this an `arbitrary` type secret?", path)
+			return nil, err
 		}
 	}
 

--- a/pkg/backends/ibmsecretsmanager_test.go
+++ b/pkg/backends/ibmsecretsmanager_test.go
@@ -1,40 +1,83 @@
 package backends_test
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/IBM/argocd-vault-plugin/pkg/backends"
+	"github.com/IBM/argocd-vault-plugin/pkg/types"
 	"github.com/IBM/go-sdk-core/v5/core"
 	ibmsm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1"
 )
 
 type MockIBMSMClient struct {
-	ListAllSecretsOptionCalledWith *ibmsm.ListAllSecretsOptions
+	ListAllSecretsOptionCalledWith []*ibmsm.ListAllSecretsOptions
 	GetSecretCalledWith            *ibmsm.GetSecretOptions
 }
 
+var BIG_GROUP_LEN int = types.IBMMaxPerPage + 1
+
+// This is used to take deep copies of struct fields passed as pointers in ListAllSecretsOptions
+// so we can make assertions about the values later
+func deepCopy(listAllSecretsOptions *ibmsm.ListAllSecretsOptions) *ibmsm.ListAllSecretsOptions {
+	var offset int64 = *listAllSecretsOptions.Offset
+	return &ibmsm.ListAllSecretsOptions{
+		Groups: listAllSecretsOptions.Groups,
+		Offset: &offset,
+	}
+}
+
 func (m *MockIBMSMClient) ListAllSecrets(listAllSecretsOptions *ibmsm.ListAllSecretsOptions) (result *ibmsm.ListSecrets, response *core.DetailedResponse, err error) {
-	m.ListAllSecretsOptionCalledWith = listAllSecretsOptions
+	m.ListAllSecretsOptionCalledWith = append(m.ListAllSecretsOptionCalledWith, deepCopy(listAllSecretsOptions))
+
+	// A big secret group
+	stype := "arbitrary"
+	bigGroupSecrets := make([]ibmsm.SecretResourceIntf, BIG_GROUP_LEN)
+	for id := 0; id < BIG_GROUP_LEN; id += 1 {
+		name := fmt.Sprintf("my-secret-%d", id)
+		bigGroupSecrets[id] = &ibmsm.SecretResource{
+			Name:       &name,
+			SecretType: &stype,
+			ID:         &name,
+		}
+	}
+
+	// A small secret  group
 	name := "my-secret"
 	id := "123"
-	stype := "arbitrary"
 	otype := "username_password"
-	return &ibmsm.ListSecrets{
-		Resources: []ibmsm.SecretResourceIntf{
-			&ibmsm.SecretResource{
-				Name:       &name,
-				SecretType: &stype,
-				ID:         &id,
-			},
-			&ibmsm.SecretResource{
-				Name:       &name,
-				SecretType: &otype,
-				ID:         &id,
-			},
+	smallGroupSecrets := []ibmsm.SecretResourceIntf{
+		&ibmsm.SecretResource{
+			Name:       &name,
+			SecretType: &stype,
+			ID:         &id,
 		},
-	}, nil, nil
+		&ibmsm.SecretResource{
+			Name:       &name,
+			SecretType: &otype,
+			ID:         &id,
+		},
+	}
+
+	if listAllSecretsOptions.Groups[0] == "big-group" {
+		// Emulate a 2-page paginated response
+		offset := int(*listAllSecretsOptions.Offset)
+
+		end := offset + types.IBMMaxPerPage
+		if end > BIG_GROUP_LEN {
+			end = BIG_GROUP_LEN
+		}
+
+		return &ibmsm.ListSecrets{
+			Resources: bigGroupSecrets[offset:end],
+		}, nil, nil
+	} else {
+		return &ibmsm.ListSecrets{
+			Resources: smallGroupSecrets,
+		}, nil, nil
+	}
 }
 
 func (m *MockIBMSMClient) GetSecret(getSecretOptions *ibmsm.GetSecretOptions) (result *ibmsm.GetSecret, response *core.DetailedResponse, err error) {
@@ -75,21 +118,25 @@ func (m *MockIBMSMClient) GetSecret(getSecretOptions *ibmsm.GetSecretOptions) (r
 
 func TestIBMSecretsManagerGetSecrets(t *testing.T) {
 
-	mock := MockIBMSMClient{}
-	sm := backends.NewIBMSecretsManagerBackend(&mock)
-
 	t.Run("Retrieves arbitrary secrets from a group", func(t *testing.T) {
+		mock := MockIBMSMClient{}
+		sm := backends.NewIBMSecretsManagerBackend(&mock)
 		res, err := sm.GetSecrets("ibmcloud/arbitrary/secrets/groups/test-group-id", "", nil)
 		if err != nil {
 			t.FailNow()
 		}
 
-		// Properly calls ListSecrets
+		// Properly calls ListSecrets the right number of times
+		var offset int64 = 0
 		expectedListArgs := &ibmsm.ListAllSecretsOptions{
 			Groups: []string{"test-group-id"},
+			Offset: &offset,
 		}
-		if !reflect.DeepEqual(mock.ListAllSecretsOptionCalledWith, expectedListArgs) {
-			t.Errorf("expectedListArgs: %s, got: %s.", expectedListArgs.Groups, mock.ListAllSecretsOptionCalledWith.Groups)
+		if !reflect.DeepEqual(mock.ListAllSecretsOptionCalledWith[0], expectedListArgs) {
+			t.Errorf("expectedListArgs: %s, got: %s.", expectedListArgs.Groups, mock.ListAllSecretsOptionCalledWith[0].Groups)
+		}
+		if len(mock.ListAllSecretsOptionCalledWith) > 1 {
+			t.Errorf("ListAllSecrets should be called %d times got %d", 1, len(mock.ListAllSecretsOptionCalledWith))
 		}
 
 		// Properly calls GetSecret
@@ -112,7 +159,45 @@ func TestIBMSecretsManagerGetSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("Paginates through groups with > IBMMaxPerPage secrets", func(t *testing.T) {
+		mock := MockIBMSMClient{}
+		sm := backends.NewIBMSecretsManagerBackend(&mock)
+
+		res, err := sm.GetSecrets("ibmcloud/arbitrary/secrets/groups/big-group", "", nil)
+		if err != nil {
+			t.FailNow()
+		}
+
+		// Properly calls ListSecrets
+		var offset int64 = 0
+		var offset2 int64 = 200
+		expectedListArgs := []*ibmsm.ListAllSecretsOptions{
+			&ibmsm.ListAllSecretsOptions{
+				Groups: []string{"big-group"},
+				Offset: &offset,
+			},
+			&ibmsm.ListAllSecretsOptions{
+				Groups: []string{"big-group"},
+				Offset: &offset2,
+			},
+		}
+		if len(mock.ListAllSecretsOptionCalledWith) != 2 {
+			t.Fatalf("ListAllSecrets should be called %d times got %d", 2, len(mock.ListAllSecretsOptionCalledWith))
+		}
+		if !reflect.DeepEqual(mock.ListAllSecretsOptionCalledWith, expectedListArgs) {
+			t.Errorf("ListAllSecrets was not called with the right arguments")
+			t.Errorf("%d", *mock.ListAllSecretsOptionCalledWith[0].Offset)
+			t.Errorf("%d", *mock.ListAllSecretsOptionCalledWith[1].Offset)
+		}
+		if len(res) != BIG_GROUP_LEN {
+			t.Fatalf("GetSecrets did not retrieve all the secrets")
+		}
+	})
+
 	t.Run("Handles paths missing secret group and type", func(t *testing.T) {
+		mock := MockIBMSMClient{}
+		sm := backends.NewIBMSecretsManagerBackend(&mock)
+
 		_, err := sm.GetSecrets("secret/data/my-secret", "", nil)
 		if err == nil {
 			t.FailNow()
@@ -124,17 +209,25 @@ func TestIBMSecretsManagerGetSecrets(t *testing.T) {
 	})
 
 	t.Run("Helpful message for secrets that are not `arbitrary` type", func(t *testing.T) {
+		mock := MockIBMSMClient{}
+		sm := backends.NewIBMSecretsManagerBackend(&mock)
+
 		m, err := sm.GetSecrets("ibmcloud/username_password/secrets/groups/test-group-id", "", nil)
 		if err == nil {
 			t.Fatalf("%s", m)
 		}
 
 		// Properly calls ListSecrets
+		var offset int64 = 0
 		expectedListArgs := &ibmsm.ListAllSecretsOptions{
 			Groups: []string{"test-group-id"},
+			Offset: &offset,
 		}
-		if !reflect.DeepEqual(mock.ListAllSecretsOptionCalledWith, expectedListArgs) {
-			t.Errorf("expectedListArgs: %s, got: %s.", expectedListArgs.Groups, mock.ListAllSecretsOptionCalledWith.Groups)
+		if !reflect.DeepEqual(mock.ListAllSecretsOptionCalledWith[0], expectedListArgs) {
+			t.Errorf("expectedListArgs: %s, got: %s.", expectedListArgs.Groups, mock.ListAllSecretsOptionCalledWith[0].Groups)
+		}
+		if len(mock.ListAllSecretsOptionCalledWith) > 1 {
+			t.Errorf("ListAllSecrets should be called %d times got %d", 1, len(mock.ListAllSecretsOptionCalledWith))
 		}
 
 		// Properly calls GetSecret

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	gcpsm "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
@@ -117,6 +118,9 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			client.EnableRetries(types.IBMMaxRetries, time.Duration(types.IBMRetryIntervalSeconds)*time.Second)
+
 			backend = backends.NewIBMSecretsManagerBackend(client)
 		}
 	case types.AWSSecretsManagerbackend:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -290,9 +290,9 @@ func TestNewConfigMissingParameter(t *testing.T) {
 		},
 		{
 			map[string]interface{}{
-				"AVP_TYPE":            "azurekeyvault",
-				"AZURE_TENANT_ID":     "test",
-				"AZURE_CLIENT_ID":     "test",
+				"AVP_TYPE":        "azurekeyvault",
+				"AZURE_TENANT_ID": "test",
+				"AZURE_CLIENT_ID": "test",
 			},
 			"*backends.AzureKeyVault",
 		},

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -30,6 +30,9 @@ const (
 	IAMAuth                  = "iam"
 	AwsDefaultRegion         = "us-east-2"
 	GCPCurrentSecretVersion  = "latest"
+	IBMMaxRetries            = 3
+	IBMRetryIntervalSeconds  = 20
+	IBMMaxPerPage            = 200
 
 	// Supported annotations
 	AVPPathAnnotation          = "avp.kubernetes.io/path"


### PR DESCRIPTION
### Description

Uses goroutines to have 20 concurrent requests to the IBM SM API at any given time, so that we are able to retrieve the payloads for all secrets in a group faster. Previously we were retrieving them sequentially. To avoid rate limit problems, the IBM SM SDK is instantiated with a setting to do 3 retries, 20 second apart for each request. 

Also handles pagination in IBM SM - [a group with more than 200 secrets requires additional API calls to get the rest](https://cloud.ibm.com/apidocs/secrets-manager#list-all-secrets-request). Logic is added to AVP to handle this. 

**Partially addresses:** #207 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
