### PR TITLE
refactor: Add GetIndividualSecret method to backends

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -320,6 +320,9 @@ For Azure, `path` is the unique name of your key vault.
 
 **Note**: Versioning is only supported for inline paths.
 
+**Note**: Due to the way the Azure backend works, templates that use _inline-path placeholders are more efficient_
+(fewer HTTP calls and therefore lower chance of hitting rate limit) than generic placeholders.
+
 These are the parameters for Azure:
 ```
 AVP_TYPE: azurekeyvault

--- a/pkg/backends/awssecretsmanager.go
+++ b/pkg/backends/awssecretsmanager.go
@@ -54,3 +54,14 @@ func (a *AWSSecretsManager) GetSecrets(path string, version string, annotations 
 
 	return dat, nil
 }
+
+// GetIndividualSecret will get the specific secret (placeholder) from the SM backend
+// For AWS, we only support placeholders replaced from the k/v pairs of a secret which cannot be individually addressed
+// So, we use GetSecrets and extract the specific placeholder we want
+func (a *AWSSecretsManager) GetIndividualSecret(kvpath, secret, version string, annotations map[string]string) (interface{}, error) {
+	data, err := a.GetSecrets(kvpath, version, annotations)
+	if err != nil {
+		return nil, err
+	}
+	return data[secret], nil
+}

--- a/pkg/backends/awssecretsmanager_test.go
+++ b/pkg/backends/awssecretsmanager_test.go
@@ -48,6 +48,19 @@ func TestAWSSecretManagerGetSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("AWS GetIndividualSecret", func(t *testing.T) {
+		secret, err := sm.GetIndividualSecret("test", "test-secret", "previous", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := "previous-value"
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s.", expected, secret)
+		}
+	})
+
 	t.Run("Get secrets at specific version", func(t *testing.T) {
 		data, err := sm.GetSecrets("test", "123", map[string]string{})
 		if err != nil {

--- a/pkg/backends/azurekeyvault.go
+++ b/pkg/backends/azurekeyvault.go
@@ -36,43 +36,56 @@ func (a *AzureKeyVault) GetSecrets(kvpath string, version string, _ map[string]s
 
 	data := make(map[string]interface{})
 
-	secretList, err := a.Client.GetSecrets(ctx, kvpath, nil)
+	secretList, err := a.Client.GetSecretsComplete(ctx, kvpath, nil)
 	if err != nil {
 		return nil, err
 	}
 	// Gather all secrets in Key Vault
 	for ; secretList.NotDone(); secretList.NextWithContext(ctx) {
-		for _, secretItem := range secretList.Values() {
-			secret := path.Base(*secretItem.ID)
-			if version == "" {
-				secretResp, err := a.Client.GetSecret(ctx, kvpath, secret, "")
+		secret := path.Base(*secretList.Value().ID)
+		if version == "" {
+			secretResp, err := a.Client.GetSecret(ctx, kvpath, secret, "")
+			if err != nil {
+				return nil, err
+			}
+			data[secret] = *secretResp.Value
+			continue
+		}
+		// In Azure Key Vault the versions of a secret is first shown after running GetSecretVersions. So we need
+		// to loop through the versions for each secret in order to find the secret that has the specific version.
+		secretVersions, _ := a.Client.GetSecretVersionsComplete(ctx, kvpath, secret, nil)
+		for ; secretVersions.NotDone(); secretVersions.NextWithContext(ctx) {
+			secretVersion := secretVersions.Value()
+			// Azure Key Vault has ability to enable/disable a secret, so lets honour that
+			if !*secretVersion.Attributes.Enabled {
+				continue
+			}
+			// Secret version matched given version
+			if strings.Contains(*secretVersion.ID, version) {
+				secretResp, err := a.Client.GetSecret(ctx, kvpath, secret, version)
 				if err != nil {
 					return nil, err
 				}
 				data[secret] = *secretResp.Value
-				continue
-			}
-			// In Azure Key Vault the versions of a secret is first shown after running GetSecretVersions. So we need
-			// to loop through the versions for each secret in order to find the secret that has the specific version.
-			secretVersions, _ := a.Client.GetSecretVersions(ctx, kvpath, secret, nil)
-			for ; secretVersions.NotDone(); secretVersions.NextWithContext(ctx) {
-				for _, secretVersion := range secretVersions.Values() {
-					// Azure Key Vault has ability to enable/disable a secret, so lets honour that
-					if !*secretVersion.Attributes.Enabled {
-						continue
-					}
-					// Secret version matched given version
-					if strings.Contains(*secretVersion.ID, version) {
-						secretResp, err := a.Client.GetSecret(ctx, kvpath, secret, version)
-						if err != nil {
-							return nil, err
-						}
-						data[secret] = *secretResp.Value
-					}
-				}
 			}
 		}
 	}
 
 	return data, nil
+}
+
+// GetIndividualSecret will get the specific secret (placeholder) from the SM backend
+// For Azure Key Vault, `kvpath` is the unique name of your vault
+// Secrets (placeholders) are directly addressable via the API, so only one call is needed here
+func (a *AzureKeyVault) GetIndividualSecret(kvpath, secret, version string, annotations map[string]string) (interface{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	kvpath = fmt.Sprintf("https://%s.vault.azure.net", kvpath)
+	data, err := a.Client.GetSecret(ctx, kvpath, secret, version)
+	if err != nil {
+		return nil, err
+	}
+
+	return *data.Value, nil
 }

--- a/pkg/backends/azurekeyvault_test.go
+++ b/pkg/backends/azurekeyvault_test.go
@@ -255,6 +255,19 @@ func TestAzureKeyVault_GetSecrets(t *testing.T) {
 
 	})
 
+	t.Run("Azure GetIndividualSecret", func(t *testing.T) {
+		secret, err := kv.GetIndividualSecret("test", "bar", "33740fc26214497f8904d93f20f7db6c", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := "baz-version"
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s.", expected, secret)
+		}
+	})
+
 	t.Run("Azure retrieve secrets with version disabled", func(t *testing.T) {
 
 		// test disabled secret

--- a/pkg/backends/gcpsecretmanager.go
+++ b/pkg/backends/gcpsecretmanager.go
@@ -63,3 +63,14 @@ func (a *GCPSecretManager) GetSecrets(path string, version string, annotations m
 
 	return data, nil
 }
+
+// GetIndividualSecret will get the specific secret (placeholder) from the SM backend
+// For GCP, the path is specific to the secret
+// So, we just forward the value from the k/v result of GetSecrets
+func (a *GCPSecretManager) GetIndividualSecret(kvpath, secret, version string, annotations map[string]string) (interface{}, error) {
+	data, err := a.GetSecrets(kvpath, version, annotations)
+	if err != nil {
+		return nil, err
+	}
+	return data[secret], nil
+}

--- a/pkg/backends/gcpsecretmanager_test.go
+++ b/pkg/backends/gcpsecretmanager_test.go
@@ -59,6 +59,19 @@ func TestGCPSecretManagerGetSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("GCP GetIndividualSecret", func(t *testing.T) {
+		secret, err := sm.GetIndividualSecret("projects/project/secrets/test-secret", "test-secret", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := []byte("some-value")
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s", expected, secret)
+		}
+	})
+
 	t.Run("GCP retrieve secrets at version", func(t *testing.T) {
 		data, err := sm.GetSecrets("projects/project/secrets/test-secret", "v3", map[string]string{})
 		if err != nil {

--- a/pkg/backends/ibmsecretsmanager.go
+++ b/pkg/backends/ibmsecretsmanager.go
@@ -159,3 +159,14 @@ func (i *IBMSecretsManager) GetSecrets(path string, version string, annotations 
 
 	return secrets, nil
 }
+
+// GetIndividualSecret will get the specific secret (placeholder) from the SM backend
+// For IBM, we only support placeholders replaced from arbitrary secrets in a group, which cannot be individually addressed by placeholder
+// So, we use GetSecrets and extract the specific placeholder we want
+func (i *IBMSecretsManager) GetIndividualSecret(kvpath, secret, version string, annotations map[string]string) (interface{}, error) {
+	data, err := i.GetSecrets(kvpath, version, annotations)
+	if err != nil {
+		return nil, err
+	}
+	return data[secret], nil
+}

--- a/pkg/backends/ibmsecretsmanager_test.go
+++ b/pkg/backends/ibmsecretsmanager_test.go
@@ -194,6 +194,22 @@ func TestIBMSecretsManagerGetSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("IBM SM GetIndividualSecret", func(t *testing.T) {
+		mock := MockIBMSMClient{}
+		sm := backends.NewIBMSecretsManagerBackend(&mock)
+
+		secret, err := sm.GetIndividualSecret("ibmcloud/arbitrary/secrets/groups/small-group", "my-secret", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := "password"
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s", expected, secret)
+		}
+	})
+
 	t.Run("Handles paths missing secret group and type", func(t *testing.T) {
 		mock := MockIBMSMClient{}
 		sm := backends.NewIBMSecretsManagerBackend(&mock)

--- a/pkg/backends/vault.go
+++ b/pkg/backends/vault.go
@@ -82,3 +82,14 @@ func (v *Vault) GetSecrets(path string, version string, annotations map[string]s
 
 	return nil, errors.New("Unsupported kvVersion specified")
 }
+
+// GetIndividualSecret will get the specific secret (placeholder) from the SM backend
+// For Vault, we only support placeholders replaced from the k/v pairs of a secret which cannot be individually addressed
+// So, we use GetSecrets and extract the specific placeholder we want
+func (v *Vault) GetIndividualSecret(kvpath, secret, version string, annotations map[string]string) (interface{}, error) {
+	data, err := v.GetSecrets(kvpath, version, annotations)
+	if err != nil {
+		return nil, err
+	}
+	return data[secret], nil
+}

--- a/pkg/backends/vault_test.go
+++ b/pkg/backends/vault_test.go
@@ -71,6 +71,21 @@ func TestVaultGetSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("Vault GetIndividualSecret", func(t *testing.T) {
+		secret, err := backend.GetIndividualSecret("kv/data/test", "hello", "", map[string]string{
+			types.VaultKVVersionAnnotation: "2",
+		})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := "world"
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s", expected, secret)
+		}
+	})
+
 	t.Run("will honor version with kv2", func(t *testing.T) {
 		annotations := map[string]string{
 			types.VaultKVVersionAnnotation: "2",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,12 @@ type Config struct {
 	Backend types.Backend
 }
 
+var backendPrefixes []string = []string{
+	"vault",
+	"aws",
+	"azure",
+}
+
 // New returns a new Config struct
 func New(v *viper.Viper, co *Options) (*Config, error) {
 
@@ -194,15 +200,17 @@ func readConfigOrSecret(secretName, configPath string, v *viper.Viper) error {
 	}
 
 	for k, viperValue := range v.AllSettings() {
-		if strings.HasPrefix(k, "vault") || strings.HasPrefix(k, "aws") {
-			var value string
-			switch viperValue.(type) {
-			case bool:
-				value = strconv.FormatBool(viperValue.(bool))
-			default:
-				value = viperValue.(string)
+		for _, prefix := range backendPrefixes {
+			if strings.HasPrefix(k, prefix) {
+				var value string
+				switch viperValue.(type) {
+				case bool:
+					value = strconv.FormatBool(viperValue.(bool))
+				default:
+					value = viperValue.(string)
+				}
+				os.Setenv(strings.ToUpper(k), value)
 			}
-			os.Setenv(strings.ToUpper(k), value)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ var backendPrefixes []string = []string{
 	"vault",
 	"aws",
 	"azure",
+	"google",
 }
 
 // New returns a new Config struct

--- a/pkg/helpers/test_helpers.go
+++ b/pkg/helpers/test_helpers.go
@@ -301,8 +301,9 @@ func CreateTestAuthVault(t *testing.T) *vault.TestCluster {
 // MockVault is used to mock out a generic SM Backend
 // It's useful for testing replacement behavior
 type MockVault struct {
-	GetSecretsCalled bool
-	Data             []map[string]interface{}
+	GetSecretsCalled          bool
+	GetIndividualSecretCalled bool
+	Data                      []map[string]interface{}
 }
 
 func (v *MockVault) Login() error {
@@ -321,4 +322,15 @@ func (v *MockVault) GetSecrets(path string, version string, annotations map[stri
 	}
 	num, _ := strconv.ParseInt(version, 10, 0)
 	return v.Data[num-1], nil
+}
+func (v *MockVault) GetIndividualSecret(path, secret, version string, annotations map[string]string) (interface{}, error) {
+	v.GetIndividualSecretCalled = true
+	if len(v.Data) == 0 {
+		return nil, nil
+	}
+	if version == "" {
+		return v.Data[len(v.Data)-1][secret], nil
+	}
+	num, _ := strconv.ParseInt(version, 10, 0)
+	return v.Data[num-1][secret], nil
 }

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -125,6 +125,7 @@ func genericReplacement(key, value string, resource Resource) (_ interface{}, er
 		}
 
 		var secretValue interface{}
+		var secretErr error
 		// Check to see if should call out to get individual secret (inline-path in placeholder)
 		// This can include an optional version argument - if unspecified, the latest version is retrieved
 		if indivPlaceholderSyntax.Match([]byte(placeholder)) {
@@ -133,14 +134,11 @@ func genericReplacement(key, value string, resource Resource) (_ interface{}, er
 			key := indivSecretMatches[indivPlaceholderSyntax.SubexpIndex("key")]
 			version := indivSecretMatches[indivPlaceholderSyntax.SubexpIndex("version")]
 
-			secrets, secretErr := resource.Backend.GetSecrets(path, version, resource.Annotations)
+			secretValue, secretErr = resource.Backend.GetIndividualSecret(path, strings.TrimSpace(key), version, resource.Annotations)
 			if secretErr != nil {
 				err = append(err, secretErr)
 				return match
 			}
-
-			secretKey := strings.TrimSpace(key)
-			secretValue = secrets[secretKey]
 		} else {
 			secretValue = resource.Data[placeholder]
 		}

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -92,7 +92,7 @@ func TestGenericReplacement_specificPath(t *testing.T) {
 
 	replaceInner(&dummyResource, &dummyResource.TemplateData, genericReplacement)
 
-	if !mv.GetSecretsCalled {
+	if !mv.GetIndividualSecretCalled {
 		t.Fatalf("expected GetSecrets to be called since placeholder contains explicit path so Vault lookup is neeed")
 	}
 
@@ -140,7 +140,7 @@ func TestGenericReplacement_specificPathVersioned(t *testing.T) {
 
 	replaceInner(&dummyResource, &dummyResource.TemplateData, genericReplacement)
 
-	if !mv.GetSecretsCalled {
+	if !mv.GetIndividualSecretCalled {
 		t.Fatalf("expected GetSecrets to be called since placeholder contains explicit path so Vault lookup is neeed")
 	}
 
@@ -180,7 +180,7 @@ func TestGenericReplacement_specificPathNoAnnotation(t *testing.T) {
 
 	replaceInner(&dummyResource, &dummyResource.TemplateData, genericReplacement)
 
-	if !mv.GetSecretsCalled {
+	if !mv.GetIndividualSecretCalled {
 		t.Fatalf("expected GetSecrets to be called since placeholder contains explicit path, was not")
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,6 +12,9 @@ type Backend interface {
 
 	// GetSecrets retrieves the secret at `path` with specified `version` based on configuation given in `annotations`
 	GetSecrets(path string, version string, annotations map[string]string) (map[string]interface{}, error)
+
+	// GetIndividualSecret retrieves the specific secret from `path` with specified `version` based on configuation given in `annotations`
+	GetIndividualSecret(path, secret, version string, annotations map[string]string) (interface{}, error)
 }
 
 // AuthType is and interface for the supported authentication methods


### PR DESCRIPTION
### Description

As discussed in https://github.com/IBM/argocd-vault-plugin/issues/207#issuecomment-926098403, we add a new method to the backend interface so that SM backends that can address individual secrets (placeholders) like Azure can be sped up considerably when using inline-path placeholders. Backends that cannot do this just call `GetSecrets` and return the single value from the k/v pair, just like what was done previously. 

Also forward config keys prefixed with `azure` and `google` to the corresponding SDK for making auth easier.

**Fixes:** #207 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
